### PR TITLE
Implement theme toggle and gallery overlays

### DIFF
--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -1182,3 +1182,38 @@ button:disabled {
 .login-button:hover {
   background: #333;
 }
+
+/* Gallery Overlay Actions */
+.gallery-image-container {
+  position: relative;
+}
+
+.gallery-overlay {
+  position: absolute;
+  inset: 0;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  gap: 10px;
+  background: rgba(0, 0, 0, 0.6);
+  opacity: 0;
+  transition: opacity 0.2s ease;
+}
+
+.gallery-image-container:hover .gallery-overlay {
+  opacity: 1;
+}
+
+.gallery-overlay button {
+  background: var(--mj-accent);
+  color: #fff;
+  border: none;
+  padding: 6px 10px;
+  border-radius: 4px;
+  cursor: pointer;
+  font-size: 12px;
+}
+
+.gallery-overlay button:hover {
+  background: var(--mj-accent-hover);
+}

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -19,6 +19,21 @@
   --mj-spacing-xl: 32px;
 }
 
+body.light-theme {
+  --mj-bg-primary: #ffffff;
+  --mj-bg-secondary: #f0f0f0;
+  --mj-bg-tertiary: #e0e0e0;
+  --mj-bg-hover: #ddd;
+  --mj-text-primary: #000000;
+  --mj-text-secondary: #333333;
+  --mj-accent: #1a9fff;
+  --mj-accent-hover: #0d8de8;
+  --mj-error: #d32f2f;
+  --mj-success: #388e3c;
+  --mj-warning: #f57c00;
+  --mj-border-color: #cccccc;
+}
+
 body {
   margin: 0;
   font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen,

--- a/frontend/src/index.js
+++ b/frontend/src/index.js
@@ -4,6 +4,16 @@ import "./index.css";
 import "./midjourney-theme.css"; // Import the Midjourney-style theme
 import App from "./App";
 
+// Apply saved theme preference before rendering
+try {
+  const prefs = JSON.parse(localStorage.getItem("comfyui_preferences") || "{}");
+  if (prefs.darkMode === false) {
+    document.body.classList.add("light-theme");
+  }
+} catch (err) {
+  console.error("Failed to load theme preference", err);
+}
+
 const root = ReactDOM.createRoot(document.getElementById("root"));
 root.render(
   <React.StrictMode>

--- a/frontend/src/pages/GalleryPage.js
+++ b/frontend/src/pages/GalleryPage.js
@@ -92,6 +92,14 @@ const GalleryPage = () => {
       showToast('Image deleted successfully', 'success');
     }
   };
+
+  const handleUpscale = (image) => {
+    showToast(`Upscale triggered for ${image.id}`, 'info');
+  };
+
+  const handleZoomOut = (image) => {
+    showToast(`Zoom out triggered for ${image.id}`, 'info');
+  };
   
   const showToast = (message, type = 'info') => {
     setToast({ message, type });
@@ -151,12 +159,16 @@ const GalleryPage = () => {
           {filteredImages.map(image => (
             <div key={image.id} className="gallery-card">
               <div className="gallery-image-container" onClick={() => handleImageClick(image)}>
-                <img 
-                  src={image.url} 
-                  alt={image.prompt} 
+                <img
+                  src={image.url}
+                  alt={image.prompt}
                   className="gallery-image"
                   loading="lazy"
                 />
+                <div className="gallery-overlay">
+                  <button onClick={(e) => { e.stopPropagation(); handleUpscale(image); }}>Upscale</button>
+                  <button onClick={(e) => { e.stopPropagation(); handleZoomOut(image); }}>Zoom Out</button>
+                </div>
               </div>
               
               <div className="gallery-image-info">

--- a/frontend/src/pages/SettingsPage.js
+++ b/frontend/src/pages/SettingsPage.js
@@ -39,12 +39,22 @@ const SettingsPage = () => {
     const savedPreferences = localStorage.getItem('comfyui_preferences');
     if (savedPreferences) {
       try {
-        setPreferences(JSON.parse(savedPreferences));
+        const prefs = JSON.parse(savedPreferences);
+        setPreferences(prefs);
       } catch (error) {
         console.error('Error parsing saved preferences:', error);
       }
     }
   }, [currentUser]);
+
+  // Apply theme when preference changes
+  useEffect(() => {
+    if (preferences.darkMode) {
+      document.body.classList.remove('light-theme');
+    } else {
+      document.body.classList.add('light-theme');
+    }
+  }, [preferences.darkMode]);
   
   const handleProfileChange = (e) => {
     const { name, value } = e.target;
@@ -56,10 +66,18 @@ const SettingsPage = () => {
   
   const handlePreferenceChange = (e) => {
     const { name, value, type, checked } = e.target;
-    setPreferences({
+    const updated = {
       ...preferences,
       [name]: type === 'checkbox' ? checked : value
-    });
+    };
+    setPreferences(updated);
+    if (name === 'darkMode') {
+      if (type === 'checkbox' ? checked : value) {
+        document.body.classList.remove('light-theme');
+      } else {
+        document.body.classList.add('light-theme');
+      }
+    }
   };
   
   const handleSaveProfile = async (e) => {


### PR DESCRIPTION
## Summary
- add light theme variables
- apply stored theme preference on load
- allow changing theme in Settings page
- add hover overlay actions in gallery images

## Testing
- `pytest -q` *(fails: ProxyError)*

------
https://chatgpt.com/codex/tasks/task_b_683ca3ae913c83299967e2439b52c340