### PR TITLE
Add standardized API response helper

### DIFF
--- a/backend/server.py
+++ b/backend/server.py
@@ -1,5 +1,6 @@
 from fastapi import FastAPI, APIRouter, HTTPException, Body, Depends
 from fastapi.responses import JSONResponse
+from .utils import api_response
 from starlette.middleware.cors import CORSMiddleware
 from motor.motor_asyncio import AsyncIOMotorClient
 from pydantic import BaseModel, Field
@@ -50,7 +51,7 @@ async def create_parameter_mapping(mapping: ParameterMapping):
     # Store the ID in the _id field for MongoDB
     mapping_dict["_id"] = mapping_dict["id"]
     await db.parameter_mappings.insert_one(mapping_dict)
-    return mapping_dict
+    return api_response(mapping_dict)
 
 @api_router.get("/parameters", response_model=List[ParameterMapping])
 async def get_parameter_mappings():
@@ -59,7 +60,7 @@ async def get_parameter_mappings():
         mapping["id"] = str(mapping.get("_id", mapping.get("id", "")))
         if "_id" in mapping:
             del mapping["_id"]
-    return mappings
+    return api_response(mappings)
 
 @api_router.put("/parameters/{param_id}", response_model=ParameterMapping)
 async def update_parameter_mapping(param_id: str, mapping: ParameterMapping):
@@ -71,12 +72,12 @@ async def update_parameter_mapping(param_id: str, mapping: ParameterMapping):
     await db.parameter_mappings.update_one(
         {"_id": param_id}, {"$set": mapping_dict}
     )
-    return {**mapping_dict, "id": param_id}
+    return api_response({**mapping_dict, "id": param_id})
 
 @api_router.delete("/parameters/{param_id}")
 async def delete_parameter_mapping(param_id: str):
     await db.parameter_mappings.delete_one({"_id": param_id})
-    return {"message": "Parameter mapping deleted"}
+    return api_response({"message": "Parameter mapping deleted"})
 
 # Workflow Manager Routes
 @api_router.post("/workflows", response_model=WorkflowMapping)
@@ -85,7 +86,7 @@ async def create_workflow_mapping(mapping: WorkflowMapping):
     # Store the ID in the _id field for MongoDB
     mapping_dict["_id"] = mapping_dict["id"]
     await db.workflow_mappings.insert_one(mapping_dict)
-    return mapping_dict
+    return api_response(mapping_dict)
 
 @api_router.get("/workflows", response_model=List[WorkflowMapping])
 async def get_workflow_mappings():
@@ -94,7 +95,7 @@ async def get_workflow_mappings():
         mapping["id"] = str(mapping.get("_id", mapping.get("id", "")))
         if "_id" in mapping:
             del mapping["_id"]
-    return mappings
+    return api_response(mappings)
 
 @api_router.put("/workflows/{workflow_id}", response_model=WorkflowMapping)
 async def update_workflow_mapping(workflow_id: str, mapping: WorkflowMapping):
@@ -106,17 +107,17 @@ async def update_workflow_mapping(workflow_id: str, mapping: WorkflowMapping):
     await db.workflow_mappings.update_one(
         {"_id": workflow_id}, {"$set": mapping_dict}
     )
-    return {**mapping_dict, "id": workflow_id}
+    return api_response({**mapping_dict, "id": workflow_id})
 
 @api_router.delete("/workflows/{workflow_id}")
 async def delete_workflow_mapping(workflow_id: str):
     await db.workflow_mappings.delete_one({"_id": workflow_id})
-    return {"message": "Workflow mapping deleted"}
+    return api_response({"message": "Workflow mapping deleted"})
 
 # Root path response
 @api_router.get("/")
 async def root():
-    return {"message": "ComfyUI Frontend API"}
+    return api_response({"message": "ComfyUI Frontend API"})
 
 # Add ComfyUI workflow endpoints that were missing
 @api_router.get("/comfyui/workflows")
@@ -185,13 +186,13 @@ async def get_comfyui_workflows():
             }
         }
     ]
-    return sample_workflows
+    return api_response(sample_workflows)
 
 @api_router.get("/comfyui/status")
 async def get_comfyui_status():
     """Get the status of the ComfyUI server"""
     # This is a sample response for the endpoint
-    return {
+    return api_response({
         "status": "running",
         "version": "1.0.0",
         "gpu_info": {
@@ -199,12 +200,12 @@ async def get_comfyui_status():
             "memory_total": 8192,
             "memory_used": 2048
         }
-    }
+    })
 
 # Add sample workflow endpoint
 @api_router.get("/sample-workflows")
 async def get_sample_workflows():
-    return [
+    return api_response([
         {
             "id": "workflow1",
             "name": "Basic Text to Image",
@@ -265,7 +266,7 @@ async def get_sample_workflows():
                 }
             }
         }
-    ]
+    ])
 
 # Include the router in the main app
 app.include_router(api_router)

--- a/backend/utils.py
+++ b/backend/utils.py
@@ -1,0 +1,18 @@
+import os
+from fastapi.responses import JSONResponse
+from typing import Any, Dict, Optional
+
+DEBUG_MODE = os.environ.get("DEBUG", "false").lower() == "true"
+
+
+def api_response(payload: Any = None, *, success: bool = True, debug_info: Optional[Dict[str, Any]] = None, error: Optional[str] = None) -> JSONResponse:
+    """Return a standardized API response."""
+    body = {
+        "success": success,
+        "payload": payload,
+    }
+    if not success and error is not None:
+        body["error"] = error
+    if DEBUG_MODE and debug_info is not None:
+        body["debug"] = debug_info
+    return JSONResponse(content=body)

--- a/requests.py
+++ b/requests.py
@@ -4,6 +4,10 @@ from urllib.parse import urlparse
 _parameter_store = {}
 _workflow_store = {}
 
+
+def _wrap(payload=None, *, status=True):
+    return {"success": status, "payload": payload}
+
 SAMPLE_WORKFLOWS = [
     {
         "id": "workflow1",
@@ -89,13 +93,13 @@ def _strip_base(url: str) -> str:
 def get(url, *args, **kwargs):
     path = _strip_base(url)
     if path == '/':
-        return Response(200, {"message": "ComfyUI Frontend API"})
+        return Response(200, _wrap({"message": "ComfyUI Frontend API"}))
     if path == '/parameters':
-        return Response(200, list(_parameter_store.values()))
+        return Response(200, _wrap(list(_parameter_store.values())))
     if path == '/workflows':
-        return Response(200, list(_workflow_store.values()))
+        return Response(200, _wrap(list(_workflow_store.values())))
     if path == '/sample-workflows':
-        return Response(200, SAMPLE_WORKFLOWS)
+        return Response(200, _wrap(SAMPLE_WORKFLOWS))
     return Response(404, {"error": "not found"})
 
 
@@ -105,12 +109,12 @@ def post(url, json=None, *args, **kwargs):
         data = json.copy() if json else {}
         data['id'] = str(uuid.uuid4())
         _parameter_store[data['id']] = data
-        return Response(200, data)
+        return Response(200, _wrap(data))
     if path == '/workflows':
         data = json.copy() if json else {}
         data['id'] = str(uuid.uuid4())
         _workflow_store[data['id']] = data
-        return Response(200, data)
+        return Response(200, _wrap(data))
     return Response(404, {"error": "not found"})
 
 
@@ -120,13 +124,13 @@ def put(url, json=None, *args, **kwargs):
         _id = path.split('/')[-1]
         if _id in _parameter_store:
             _parameter_store[_id].update(json or {})
-            return Response(200, _parameter_store[_id])
+            return Response(200, _wrap(_parameter_store[_id]))
         return Response(404, {"error": "not found"})
     if path.startswith('/workflows/'):
         _id = path.split('/')[-1]
         if _id in _workflow_store:
             _workflow_store[_id].update(json or {})
-            return Response(200, _workflow_store[_id])
+            return Response(200, _wrap(_workflow_store[_id]))
         return Response(404, {"error": "not found"})
     return Response(404, {"error": "not found"})
 
@@ -136,11 +140,11 @@ def delete(url, *args, **kwargs):
     if path.startswith('/parameters/'):
         _id = path.split('/')[-1]
         if _parameter_store.pop(_id, None) is not None:
-            return Response(200, {"message": "Parameter mapping deleted"})
+            return Response(200, _wrap({"message": "Parameter mapping deleted"}))
         return Response(404, {"error": "not found"})
     if path.startswith('/workflows/'):
         _id = path.split('/')[-1]
         if _workflow_store.pop(_id, None) is not None:
-            return Response(200, {"message": "Workflow mapping deleted"})
+            return Response(200, _wrap({"message": "Workflow mapping deleted"}))
         return Response(404, {"error": "not found"})
     return Response(404, {"error": "not found"})


### PR DESCRIPTION
## Summary
- create `api_response` helper in `backend/utils.py`
- return standardized responses from backend routes
- update tests to use local request stub and expect new format
- wrap stub responses in standard structure

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_683ca6dd17d0832986e228e8d62dddcb