### PR TITLE
Add simple SSE progress endpoint

### DIFF
--- a/backend/server.py
+++ b/backend/server.py
@@ -1,4 +1,5 @@
 from fastapi import FastAPI, APIRouter, HTTPException, Body, Depends, Request
+from fastapi.responses import StreamingResponse
 from .utils import api_response, DEBUG_MODE
 from starlette.middleware.cors import CORSMiddleware
 from motor.motor_asyncio import AsyncIOMotorClient
@@ -8,6 +9,8 @@ import os
 import uuid
 from datetime import datetime
 import logging
+import asyncio
+import json
 
 # Load environment variables
 from dotenv import load_dotenv
@@ -20,6 +23,9 @@ db = client.get_database("comfyui_frontend")
 
 # Create the main app
 app = FastAPI()
+
+# Simple in-memory job store for demo progress streaming
+jobs: Dict[str, Dict[str, Any]] = {}
 
 
 @app.exception_handler(HTTPException)
@@ -275,6 +281,47 @@ async def get_sample_workflows():
             }
         }
     ])
+
+# Simple workflow execution and progress streaming
+@api_router.post("/generate")
+async def start_generation(prompt: str = Body(..., embed=True)):
+    """Create a fake generation job and simulate progress."""
+    job_id = str(uuid.uuid4())
+    jobs[job_id] = {"status": "queued", "progress": 0, "prompt": prompt}
+
+    async def run_job(jid: str):
+        jobs[jid]["status"] = "generating"
+        for i in range(1, 6):
+            await asyncio.sleep(0.1)
+            jobs[jid]["progress"] = i * 20
+        jobs[jid]["status"] = "done"
+
+    asyncio.create_task(run_job(job_id))
+    return api_response({"job_id": job_id})
+
+
+@api_router.get("/progress/{job_id}")
+async def get_progress(job_id: str):
+    job = jobs.get(job_id)
+    if not job:
+        raise HTTPException(status_code=404, detail="Job not found")
+    return api_response(job)
+
+
+@api_router.get("/progress/stream/{job_id}")
+async def stream_progress(job_id: str):
+    async def event_generator():
+        while True:
+            job = jobs.get(job_id)
+            if not job:
+                yield "event: end\ndata: job_not_found\n\n"
+                break
+            yield f"data: {json.dumps(job)}\n\n"
+            if job["status"] == "done":
+                break
+            await asyncio.sleep(0.1)
+
+    return StreamingResponse(event_generator(), media_type="text/event-stream")
 
 # Include the router in the main app
 app.include_router(api_router)

--- a/todo.txt
+++ b/todo.txt
@@ -1,6 +1,6 @@
 Design a lightweight backend that proxies requests from the frontend to the ComfyUI API endpoints, including support for submitting prompts, querying image job history, and managing the active generation queue.
 
-Implement a real-time progress system using WebSockets or Server-Sent Events that pushes image generation updates and queue status to the frontend UI without polling.
+[WIP] Implement a real-time progress system using WebSockets or Server-Sent Events that pushes image generation updates and queue status to the frontend UI without polling.
 
 Standardize all backend responses to return a consistent structure including success status, payload, and full debug info or error traces if in development mode.
 


### PR DESCRIPTION
## Summary
- implement a minimal demo of real-time progress updates via SSE in backend
- mark progress streaming task as `[WIP]`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_683cabea7608832996e8becf504f2e06