### PR TITLE
Implement Explore prompt injection

### DIFF
--- a/backend/prompt_parser.py
+++ b/backend/prompt_parser.py
@@ -1,3 +1,4 @@
+import re
 import shlex
 from typing import Tuple, Dict, List, Any
 
@@ -5,17 +6,11 @@ SHORTCODE_PATTERN = re.compile(r"--(?P<key>\w+)(?:\s+(?P<value>(\"[^\"]*\"|'[^']
 
 
 def parse_prompt(prompt: str) -> Tuple[str, Dict[str, str]]:
-    """Parse a prompt string extracting shortcode parameters.
+    """Parse a prompt and extract shortcode parameters.
 
-    Supports tokens in the form ``--key value`` or ``--key=value``. Values may
-    be quoted with single or double quotes.
-    Returns ``(clean_prompt, params_dict)``.
-
-    """Parse a prompt extracting shortcode parameters.
-
-    Supports tokens in the form ``--key value`` or ``--key=value``.
-    Values may be quoted with single or double quotes.
-    Returns a tuple ``(clean_prompt, params_dict)``.
+    Supports tokens of the form ``--key value`` or ``--key=value``. Values may
+    be quoted with single or double quotes.  Returns the cleaned prompt and a
+    mapping of shortcode keys to their values.
     """
     params: Dict[str, str] = {}
     remaining_tokens: List[str] = []

--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -365,6 +365,24 @@ button:disabled {
   transition: transform 0.2s ease, box-shadow 0.2s ease;
 }
 
+.use-prompt-button {
+  position: absolute;
+  top: 8px;
+  right: 8px;
+  background: var(--accent-color);
+  color: #fff;
+  border: none;
+  padding: 4px 8px;
+  font-size: 12px;
+  border-radius: 4px;
+  cursor: pointer;
+  opacity: 0.9;
+}
+
+.use-prompt-button:hover {
+  background: var(--accent-hover);
+}
+
 .image-card:hover {
   transform: translateY(-5px);
   box-shadow: 0 5px 15px rgba(0, 0, 0, 0.3);

--- a/frontend/src/pages/CreatePage.js
+++ b/frontend/src/pages/CreatePage.js
@@ -14,6 +14,15 @@ const CreatePage = () => {
 
   const { currentUser } = useAuth();
 
+  // Load a prompt from Explore page if provided
+  useEffect(() => {
+    const imported = localStorage.getItem('imported_prompt');
+    if (imported) {
+      setPrompt(imported);
+      localStorage.removeItem('imported_prompt');
+    }
+  }, []);
+
   // Categories for the tabs
   const categories = ['Random', 'Hot', 'Top Month', 'Likes'];
   const [activeCategory, setActiveCategory] = useState('Hot');

--- a/frontend/src/pages/ExplorePage.js
+++ b/frontend/src/pages/ExplorePage.js
@@ -1,4 +1,5 @@
 import React, { useState, useEffect } from 'react';
+import { useNavigate } from 'react-router-dom';
 import { useAuth } from '../contexts/AuthContext';
 import Toast from '../components/Toast';
 
@@ -9,6 +10,8 @@ const ExplorePage = () => {
   const [searchQuery, setSearchQuery] = useState('');
   const [loading, setLoading] = useState(true);
   const [toast, setToast] = useState(null);
+
+  const navigate = useNavigate();
   
   const { currentUser } = useAuth();
   
@@ -147,6 +150,11 @@ const ExplorePage = () => {
     // Navigate to the image detail or editor page
     console.log('Image clicked:', image);
   };
+
+  const handleUsePrompt = (image) => {
+    localStorage.setItem('imported_prompt', image.prompt);
+    navigate('/');
+  };
   
   const handleModelClick = (model) => {
     // Navigate to the model detail page
@@ -231,12 +239,15 @@ const ExplorePage = () => {
             <div className="image-grid explore-grid">
               {filteredImages.map(image => (
                 <div key={image.id} className="image-card" onClick={() => handleImageClick(image)}>
-                  <img 
-                    src={image.url} 
-                    alt={image.prompt} 
+                  <img
+                    src={image.url}
+                    alt={image.prompt}
                     className="grid-image"
                     loading="lazy"
                   />
+                  <button className="use-prompt-button" onClick={(e) => { e.stopPropagation(); handleUsePrompt(image); }}>
+                    Use Prompt
+                  </button>
                   <div className="image-info">
                     <div className="image-prompt">{image.prompt}</div>
                     <div className="image-meta">

--- a/todo.txt
+++ b/todo.txt
@@ -22,7 +22,7 @@ Integrate with Civitai by allowing users to input and store their Civitai API ke
 
 Use the Civitai API to fetch and display images, prompts, and models in the Explore page, with lazy loading and infinite scrolling for browsing high volumes of results.
 
-Connect Explore-page images to the prompt system by enabling one-click "generate from this prompt" which pushes the selected prompt directly into the generation input bar.
+[DONE] Connect Explore-page images to the prompt system by enabling one-click "generate from this prompt" which pushes the selected prompt directly into the generation input bar.
 
 Implement throttling and caching when interacting with the Civitai API to respect their rate limits and usage guidelines.
 


### PR DESCRIPTION
## Summary
- clean up backend prompt parser imports and docstring
- pull prompt from Explore page into Create prompt bar
- allow Explore images to send their prompts to Create page
- add styles for new prompt button
- mark todo item complete

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_683cb0d6bcc083299f7ca00bc72b55ce