### PR TITLE
Implement secure Civitai API key storage

### DIFF
--- a/backend/prompt_parser.py
+++ b/backend/prompt_parser.py
@@ -1,3 +1,4 @@
+import re
 import shlex
 from typing import Tuple, Dict, List, Any
 
@@ -5,18 +6,7 @@ SHORTCODE_PATTERN = re.compile(r"--(?P<key>\w+)(?:\s+(?P<value>(\"[^\"]*\"|'[^']
 
 
 def parse_prompt(prompt: str) -> Tuple[str, Dict[str, str]]:
-    """Parse a prompt string extracting shortcode parameters.
-
-    Supports tokens in the form ``--key value`` or ``--key=value``. Values may
-    be quoted with single or double quotes.
-    Returns ``(clean_prompt, params_dict)``.
-
-    """Parse a prompt extracting shortcode parameters.
-
-    Supports tokens in the form ``--key value`` or ``--key=value``.
-    Values may be quoted with single or double quotes.
-    Returns a tuple ``(clean_prompt, params_dict)``.
-    """
+    """Parse a prompt extracting shortcode parameters."""
     params: Dict[str, str] = {}
     remaining_tokens: List[str] = []
 
@@ -45,8 +35,6 @@ def parse_prompt(prompt: str) -> Tuple[str, Dict[str, str]]:
             remaining_tokens.append(token)
         i += 1
 
-    clean_prompt = " ".join(remaining_tokens).strip()
-    clean_prompt = SHORTCODE_PATTERN.sub("", clean_prompt).strip()
     clean_prompt = " ".join(remaining_tokens)
     clean_prompt = SHORTCODE_PATTERN.sub("", clean_prompt).strip()
 

--- a/frontend/src/pages/HomePage.js
+++ b/frontend/src/pages/HomePage.js
@@ -87,11 +87,14 @@ const HomePage = () => {
       };
       loadWorkflows();
       
-      // Load settings
-      setSettings(prevSettings => ({
-        ...prevSettings,
-        civitaiApiKey: localStorage.getItem('civitai_api_key') || ""
-      }));
+      // Load settings from backend
+      (async () => {
+        const hasKey = await civitaiService.checkApiKey();
+        setSettings(prevSettings => ({
+          ...prevSettings,
+          civitaiApiKey: hasKey ? 'set' : ''
+        }));
+      })();
     }
   }, [currentUser]);
 

--- a/todo.txt
+++ b/todo.txt
@@ -18,7 +18,7 @@ Connect the frontend Workflow Manager UI to this backend so that users can uploa
 
 Provide visual autocomplete in the prompt bar for available parameters as users type, showing hints for each shortcode.
 
-Integrate with Civitai by allowing users to input and store their Civitai API key securely in the settings panel, encrypted and never exposed to the client or logs.
+[PARTIAL] Integrate with Civitai by allowing users to input and store their Civitai API key securely in the settings panel, encrypted and never exposed to the client or logs.
 
 Use the Civitai API to fetch and display images, prompts, and models in the Explore page, with lazy loading and infinite scrolling for browsing high volumes of results.
 


### PR DESCRIPTION
## Summary
- encrypt sensitive API keys using Fernet
- expose endpoints to store and check the Civitai API key
- adjust frontend service and settings loader to use new backend routes
- cleanup prompt parser implementation
- mark Civitai key integration as partial in todo

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_683cb0d9aa048329a7c78cd63483150f