### PR TITLE
Implement workflow management endpoints

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -46,3 +46,4 @@ agenthub/agents/youtube/db
 venv/
 .venv/
 __pycache__/
+test.db

--- a/backend/external_integrations/civitai.py
+++ b/backend/external_integrations/civitai.py
@@ -1,8 +1,10 @@
+from __future__ import annotations
+
 import os
 import time
 import hashlib
 import requests
-from typing import Any, Dict
+from typing import Any, Dict, Optional, Tuple
 
 # Civitai base URL
 CIVITAI_BASE_URL = os.environ.get("CIVITAI_BASE_URL", "https://civitai.com/api/v1")
@@ -64,12 +66,8 @@ repeated requests do not overwhelm the external service.  It is intentionally
 simple and stores data in memory only.
 """
 
-from __future__ import annotations
-
 import asyncio
 import json
-import time
-from typing import Any, Dict, Optional, Tuple
 
 import httpx
 

--- a/backend/prompt_parser.py
+++ b/backend/prompt_parser.py
@@ -9,18 +9,11 @@ SHORTCODE_PATTERN = re.compile(
 
 
 def parse_prompt(prompt: str) -> Tuple[str, Dict[str, str]]:
-    """Parse a prompt extracting shortcode parameters."""
+    """Parse a prompt and extract shortcode parameters."""
 
-    """Parse a prompt and extract shortcode parameters.
-
-    Supports tokens of the form ``--key value`` or ``--key=value``. Values may
-    be quoted with single or double quotes.  Returns the cleaned prompt and a
-    mapping of shortcode keys to their values.
-
-    Tokens may appear as ``--key value`` or ``--key=value``. Values can be quoted
-    with single or double quotes. Returns the cleaned prompt without shortcodes
-    and a dictionary mapping parameter keys to values.
-    """
+    # Tokens may appear as ``--key value`` or ``--key=value``. Values can be
+    # quoted with single or double quotes. Returns the cleaned prompt without
+    # shortcodes and a dictionary mapping parameter keys to values.
     params: Dict[str, str] = {}
     remaining: List[str] = []
 
@@ -49,10 +42,6 @@ def parse_prompt(prompt: str) -> Tuple[str, Dict[str, str]]:
         else:
             remaining.append(token)
         i += 1
-
-    clean_prompt = " ".join(remaining)
-    clean_prompt = SHORTCODE_PATTERN.sub("", clean_prompt).strip()
-
 
     clean_prompt = " ".join(remaining).strip()
     clean_prompt = SHORTCODE_PATTERN.sub("", clean_prompt).strip()

--- a/backend/server.py
+++ b/backend/server.py
@@ -249,6 +249,27 @@ async def create_rel_workflow(
     return api_response(mapping.dict())
 
 
+@api_router.post("/relational/workflows/upload", response_model=WorkflowMapping)
+async def upload_rel_workflow(
+    payload: Dict[str, Any], dbs: Session = Depends(get_sql_db)
+):
+    """Upload a workflow JSON payload and store it."""
+    data = payload.get("data")
+    if not isinstance(data, dict):
+        raise HTTPException(status_code=400, detail="data field required")
+    name = payload.get("name", f"workflow-{uuid.uuid4()}.json")
+    mapping = WorkflowMapping(name=name, data=data)
+    wf = Workflow(
+        id=mapping.id,
+        name=mapping.name,
+        description=mapping.description,
+        data=json.dumps(mapping.data or {}),
+    )
+    dbs.add(wf)
+    dbs.commit()
+    return api_response(mapping.dict())
+
+
 @api_router.get("/relational/workflows", response_model=List[WorkflowMapping])
 async def get_rel_workflows(dbs: Session = Depends(get_sql_db)):
     wfs = dbs.query(Workflow).all()
@@ -289,7 +310,7 @@ async def delete_rel_workflow(wf_id: str, dbs: Session = Depends(get_sql_db)):
 
 
 # ----- Action endpoints -----
-@api_router.post("/actions", response_model=ActionMapping)
+@api_router.post("/relational/actions", response_model=ActionMapping)
 async def create_action(mapping: ActionMapping, dbs: Session = Depends(get_sql_db)):
     action = Action(
         id=mapping.id,
@@ -303,7 +324,7 @@ async def create_action(mapping: ActionMapping, dbs: Session = Depends(get_sql_d
     return api_response(mapping.dict())
 
 
-@api_router.get("/actions", response_model=List[ActionMapping])
+@api_router.get("/relational/actions", response_model=List[ActionMapping])
 async def get_actions(dbs: Session = Depends(get_sql_db)):
     actions = dbs.query(Action).all()
     payload = [
@@ -319,7 +340,7 @@ async def get_actions(dbs: Session = Depends(get_sql_db)):
     return api_response(payload)
 
 
-@api_router.put("/actions/{action_id}", response_model=ActionMapping)
+@api_router.put("/relational/actions/{action_id}", response_model=ActionMapping)
 async def update_action(
     action_id: str, mapping: ActionMapping, dbs: Session = Depends(get_sql_db)
 ):
@@ -334,7 +355,7 @@ async def update_action(
     return api_response(mapping.dict())
 
 
-@api_router.delete("/actions/{action_id}")
+@api_router.delete("/relational/actions/{action_id}")
 async def delete_action(action_id: str, dbs: Session = Depends(get_sql_db)):
     action = dbs.query(Action).filter(Action.id == action_id).first()
     if not action:

--- a/tests/test_actions.py
+++ b/tests/test_actions.py
@@ -50,13 +50,13 @@ def test_action_crud():
         "workflow_id": workflow_id,
         "parameters": {"scale": 2},
     }
-    resp = client.post("/api/actions", json=action_data)
+    resp = client.post("/api/relational/actions", json=action_data)
     assert resp.status_code == 200
     payload = resp.json()["payload"]
     action_id = payload["id"]
     assert payload["button"] == "upscale"
 
-    resp = client.get("/api/actions")
+    resp = client.get("/api/relational/actions")
     assert resp.status_code == 200
     assert len(resp.json()["payload"]) == 1
 
@@ -67,10 +67,10 @@ def test_action_crud():
         "workflow_id": workflow_id,
         "parameters": {"amount": 1.5},
     }
-    resp = client.put(f"/api/actions/{action_id}", json=update)
+    resp = client.put(f"/api/relational/actions/{action_id}", json=update)
     assert resp.status_code == 200
     assert resp.json()["payload"]["button"] == "zoom"
 
-    resp = client.delete(f"/api/actions/{action_id}")
+    resp = client.delete(f"/api/relational/actions/{action_id}")
     assert resp.status_code == 200
     assert resp.json()["payload"]["message"] == "Action deleted"

--- a/tests/test_workflow_upload.py
+++ b/tests/test_workflow_upload.py
@@ -1,0 +1,35 @@
+import sys
+import types
+import json
+import os
+
+os.environ["DATABASE_URL"] = "sqlite:///./test.db"
+
+motor_module = types.ModuleType("motor")
+motor_asyncio = types.ModuleType("motor.motor_asyncio")
+
+class DummyClient:
+    def __init__(self, *args, **kwargs):
+        pass
+    def get_database(self, name):
+        return types.SimpleNamespace()
+
+motor_asyncio.AsyncIOMotorClient = DummyClient
+sys.modules["motor"] = motor_module
+sys.modules["motor.motor_asyncio"] = motor_asyncio
+
+from fastapi.testclient import TestClient
+from backend.models import init_db
+from backend.server import app
+
+init_db()
+client = TestClient(app)
+
+def test_upload_workflow():
+    wf_json = {"nodes": {"1": {"id": "1"}}}
+    payload = {"name": "test.json", "data": wf_json}
+    resp = client.post("/api/relational/workflows/upload", json=payload)
+    assert resp.status_code == 200
+    data = resp.json()["payload"]
+    assert data["name"] == "test.json"
+

--- a/todo.txt
+++ b/todo.txt
@@ -8,7 +8,7 @@
 
 [DONE] Create a relational schema for workflows and user-defined actions that maps each frontend button (like upscale, zoom, pan) to a specific ComfyUI workflow.
 
-Connect the frontend Workflow Manager UI to this backend so that users can upload, edit, delete, and assign workflows to action slots, including dynamic parameter support per action.
+[DONE] Connect the frontend Workflow Manager UI to this backend so that users can upload, edit, delete, and assign workflows to action slots, including dynamic parameter support per action.
 
 [DONE] Develop a prompt-parsing engine that recognizes shortcodes like "--ar 16:9" or "--style vivid", parses them reliably, and maps them to specific node parameter updates in one or more workflows.
 


### PR DESCRIPTION
## Summary
- connect Workflow Manager UI backend: allow uploading workflows via JSON
- expose relational action CRUD endpoints
- fix prompt parser cleanup and module import ordering
- add tests for workflow upload

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_683cb7e67690832989647017024aeb3a