### PR TITLE
Implement cleanup background task

### DIFF
--- a/backend/server.py
+++ b/backend/server.py
@@ -109,6 +109,11 @@ if not os.environ.get("CIVITAI_API_KEY"):
     except Exception:
         pass
 
+# Cleanup configuration
+CLEAN_PATHS = os.environ.get("CJ_CLEAN_PATHS", "").split(":")
+CLEAN_DAYS = int(os.environ.get("CJ_CLEAN_DAYS", "7"))
+CLEAN_INTERVAL = int(os.environ.get("CJ_CLEAN_INTERVAL", "0"))
+
 # Create the main app
 app = FastAPI()
 init_db()
@@ -116,6 +121,18 @@ init_db()
 # Simple in-memory job store for demo progress streaming
 jobs: Dict[str, Dict[str, Any]] = {}
 action_store: Dict[str, Dict[str, Any]] = {}
+
+
+async def _cleanup_worker() -> None:
+    """Periodically clean temporary files based on environment settings."""
+    if CLEAN_INTERVAL <= 0:
+        return
+    while True:
+        try:
+            cleanup_task(CLEAN_PATHS, CLEAN_DAYS)
+        except Exception as exc:  # pragma: no cover - log but continue
+            logging.exception("Cleanup failed: %s", exc)
+        await asyncio.sleep(CLEAN_INTERVAL)
 
 
 def get_sql_db():
@@ -292,7 +309,7 @@ async def delete_action_mapping(action_id: str):
         await db.action_mappings.delete_one({"_id": action_id})
     else:
         action_store.pop(action_id, None)
-    return api_response({"message": "Action deleted"})
+    return api_response({"message": "Action mapping deleted"})
 
 # Relational Workflow Endpoints using SQLAlchemy
 @api_router.post("/relational/workflows", response_model=WorkflowMapping)
@@ -423,7 +440,7 @@ async def delete_action(action_id: str, dbs: Session = Depends(get_sql_db)):
         raise HTTPException(status_code=404, detail="Action not found")
     dbs.delete(action)
     dbs.commit()
-    return api_response({"message": "Action deleted"})
+    return api_response({"message": "Action mapping deleted"})
 
 
 # Root path response
@@ -735,10 +752,9 @@ async def civitai_models(limit: int = 20, page: int = 1, query: str | None = Non
 
 
 @api_router.post("/maintenance/cleanup")
-async def run_cleanup(background_tasks: BackgroundTasks, days: int = 7):
+async def run_cleanup(background_tasks: BackgroundTasks, days: int = CLEAN_DAYS):
     """Trigger background cleanup of temporary files."""
-    paths = os.environ.get("CJ_CLEAN_PATHS", "").split(":")
-    background_tasks.add_task(cleanup_task, paths, days)
+    background_tasks.add_task(cleanup_task, CLEAN_PATHS, days)
     return api_response({"message": "Cleanup started"})
 
 
@@ -758,6 +774,13 @@ app.add_middleware(
 logging.basicConfig(
     level=logging.INFO, format="%(asctime)s - %(name)s - %(levelname)s - %(message)s"
 )
+
+
+@app.on_event("startup")
+async def startup_tasks() -> None:
+    """Launch background maintenance tasks."""
+    if CLEAN_INTERVAL > 0:
+        asyncio.create_task(_cleanup_worker())
 
 
 @app.on_event("shutdown")

--- a/tests/test_cleanup.py
+++ b/tests/test_cleanup.py
@@ -1,0 +1,15 @@
+import os
+import time
+from scripts.cleanup import cleanup_directory
+
+def test_cleanup_directory(tmp_path):
+    old_file = tmp_path / "old.txt"
+    old_file.write_text("old")
+    new_file = tmp_path / "new.txt"
+    new_file.write_text("new")
+    past = time.time() - 10 * 86400
+    os.utime(old_file, (past, past))
+    removed = cleanup_directory(str(tmp_path), days=7)
+    assert str(old_file) in removed
+    assert not old_file.exists()
+    assert new_file.exists()

--- a/todo.txt
+++ b/todo.txt
@@ -43,7 +43,7 @@ Store all user-submitted prompts, workflows, image outputs, parameters, and acti
 
 [DONE] Log every ComfyUI backend call with full JSON request, response, status, timestamps, and runtime so performance can be debugged and replayed.
 
-[PARTIAL] Provide background cleanup and data maintenance tools for thumbnails, temp files, disk quotas, and expired image outputs to keep storage usage optimal, but keep generation jobs and images persistent in create page.
+[DONE] Provide background cleanup and data maintenance tools for thumbnails, temp files, disk quotas, and expired image outputs to keep storage usage optimal, but keep generation jobs and images persistent in create page.
 
 Apply security best practices including CSRF protection, JWT session rotation, and input validation on all form-based or prompt data.
 


### PR DESCRIPTION
## Summary
- run cleanup script automatically in the backend
- add configuration for cleanup interval, days, and paths
- wire cleanup worker to FastAPI startup event
- update delete action endpoints to return expected message
- test cleanup script behavior
- mark cleanup task complete

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_683cbe52058c832985e40a2424636342