### PR TITLE
Improve parameter handling and output display

### DIFF
--- a/backend/prompt_parser.py
+++ b/backend/prompt_parser.py
@@ -66,21 +66,38 @@ def tokens_to_patch(
         if not mapping:
             continue
 
-        template = mapping.get("value_template", "{value}")
-        op = mapping.get("op", "replace")
-        path_template = mapping.get(
-            "path_template", "/nodes/{node_id}/properties/{param_name}"
-        )
-        try:
-            path = path_template.format(**mapping)
-        except KeyError:
-            path = f"/nodes/{mapping['node_id']}/properties/{mapping['param_name']}"
+        if mapping.get("injection_mode"):
+            path_template = mapping.get(
+                "path_template", "/nodes/{node_id}/properties/{param_name}"
+            )
+            try:
+                path = path_template.format(**mapping)
+            except KeyError:
+                path = f"/nodes/{mapping['node_id']}/properties/{mapping['param_name']}"
+            patch_ops.append(
+                {
+                    "op": "text_inject",
+                    "path": path,
+                    "mode": mapping["injection_mode"],
+                    "value": value,
+                }
+            )
+        else:
+            template = mapping.get("value_template", "{value}")
+            op = mapping.get("op", "replace")
+            path_template = mapping.get(
+                "path_template", "/nodes/{node_id}/properties/{param_name}"
+            )
+            try:
+                path = path_template.format(**mapping)
+            except KeyError:
+                path = f"/nodes/{mapping['node_id']}/properties/{mapping['param_name']}"
 
-        patch_ops.append(
-            {
-                "op": op,
-                "path": path,
-                "value": template.format(value=value),
-            }
-        )
+            patch_ops.append(
+                {
+                    "op": op,
+                    "path": path,
+                    "value": template.format(value=value),
+                }
+            )
     return patch_ops

--- a/backend/server.py
+++ b/backend/server.py
@@ -279,6 +279,7 @@ class ParameterMapping(BaseModel):
     node_id: str
     param_name: str
     value_template: str = "{value}"
+    injection_mode: Optional[str] = None
     description: str = ""
 
 
@@ -305,6 +306,7 @@ async def get_parameters():
             "node_id": r.get("node_id"),
             "param_name": r.get("param_name"),
             "value_template": r.get("value_template", "{value}"),
+            "injection_mode": r.get("injection_mode"),
             "description": r.get("description", ""),
         }
         for r in records

--- a/frontend/src/pages/CreatePage.js
+++ b/frontend/src/pages/CreatePage.js
@@ -11,7 +11,7 @@ const CreatePage = () => {
   const [suggestions, setSuggestions] = useState([]);
   const [showSuggestions, setShowSuggestions] = useState(false);
   const inputRef = useRef(null);
-  const [images, setImages] = useState([]);
+  const [outputs, setOutputs] = useState([]);
   const [loading, setLoading] = useState(false);
   const [toast, setToast] = useState(null);
   const [parameterMappings, setParameterMappings] = useState([]);
@@ -71,19 +71,21 @@ const CreatePage = () => {
 
     fetchParameterMappings();
 
-    // Load mock images for demo
+    // Load mock outputs for demo
     const mockImages = [
       {
         id: '1',
         url: 'https://source.unsplash.com/random/500x500/?space,galaxy',
         prompt: 'Tender holographic colors, Venus Botticelli with galaxy inside out, enigmatic, energetic, long exposure, optical illusion, glow aesthetics, surrounded by stars and peonies, hyper detailed, 8k, vhs sfx, 80s film grain',
-        metadata: { chaos: 33, v: 7, stylize: 1000 }
+        metadata: { chaos: 33, v: 7, stylize: 1000 },
+        type: 'image'
       },
       {
         id: '2',
         url: 'https://source.unsplash.com/random/500x500/?nebula',
         prompt: 'Tender holographic colors, Venus Botticelli with galaxy inside out, enigmatic, energetic, long exposure, optical illusion, glow aesthetics, surrounded by stars and peonies, hyper detailed, 8k, vhs sfx, 80s film grain',
-        metadata: { chaos: 33, v: 7, stylize: 200 }
+        metadata: { chaos: 33, v: 7, stylize: 200 },
+        type: 'image'
       },
       {
         id: '3',
@@ -101,29 +103,33 @@ const CreatePage = () => {
         id: '5',
         url: 'https://source.unsplash.com/random/500x500/?nebula,space',
         prompt: 'Tender holographic colors, Venus Botticelli with galaxy inside out, enigmatic, energetic, long exposure, optical illusion, glow aesthetics, surrounded by stars and peonies, hyper detailed, 8k, vhs sfx, 80s film grain',
-        metadata: { chaos: 33, v: 7, stylize: 1000 }
+        metadata: { chaos: 33, v: 7, stylize: 1000 },
+        type: 'image'
       },
       {
         id: '6',
         url: 'https://source.unsplash.com/random/500x500/?cosmos,stars',
         prompt: 'Tender holographic colors, Venus Botticelli with galaxy inside out, enigmatic, energetic, long exposure, optical illusion, glow aesthetics, surrounded by stars and peonies, hyper detailed, 8k, vhs sfx, 80s film grain',
-        metadata: { chaos: 33, v: 7, stylize: 1000 }
+        metadata: { chaos: 33, v: 7, stylize: 1000 },
+        type: 'image'
       },
       {
         id: '7',
         url: 'https://source.unsplash.com/random/500x500/?face,galaxy',
         prompt: 'Tender holographic colors, Venus Botticelli with galaxy inside out, enigmatic, energetic, long exposure, optical illusion, glow aesthetics, surrounded by stars and peonies, hyper detailed, 8k, vhs sfx, 80s film grain',
-        metadata: { chaos: 33, v: 7, stylize: 1000 }
+        metadata: { chaos: 33, v: 7, stylize: 1000 },
+        type: 'image'
       },
       {
         id: '8',
         url: 'https://source.unsplash.com/random/500x500/?stars,cosmos',
         prompt: 'Tender holographic colors, Venus Botticelli with galaxy inside out, enigmatic, energetic, long exposure, optical illusion, glow aesthetics, surrounded by stars and peonies, hyper detailed, 8k, vhs sfx, 80s film grain',
-        metadata: { chaos: 33, v: 7, stylize: 1000 }
+        metadata: { chaos: 33, v: 7, stylize: 1000 },
+        type: 'image'
       }
     ];
-    
-    setImages(mockImages);
+
+    setOutputs(mockImages);
   }, []);
 
   const handlePromptChange = (e) => {
@@ -183,19 +189,22 @@ const CreatePage = () => {
           if (!job) return;
           showToast(`Job ${job.status} (${job.progress}%)`, 'info');
           if (job.status === 'done') {
-            // Add mock images when done (demo purposes)
-            const newImages = [
+            // Add mock output when done (demo purposes)
+            const types = ['image', 'video', 'model'];
+            const outType = types[Math.floor(Math.random() * types.length)];
+            const newOutputs = [
               {
                 id: Date.now().toString(),
                 url: 'https://source.unsplash.com/random/500x500/?galaxy,nebula&' + Date.now(),
                 prompt: prompt,
-                metadata: parameters
+                metadata: parameters,
+                type: outType
               }
             ];
-            setImages(prev => [...newImages, ...prev]);
+            setOutputs(prev => [...newOutputs, ...prev]);
             setLoading(false);
             source.close();
-            showToast('Images generated successfully', 'success');
+            showToast('Generation completed', 'success');
           }
         },
         (err) => {
@@ -206,9 +215,9 @@ const CreatePage = () => {
         }
       );
     } catch (error) {
-      console.error('Error generating images:', error);
+      console.error('Error generating output:', error);
       setLoading(false);
-      showToast('Failed to generate images', 'error');
+      showToast('Failed to generate', 'error');
     }
   };
 
@@ -238,8 +247,8 @@ const CreatePage = () => {
       if (file.type.startsWith('image/')) {
         const reader = new FileReader();
         reader.onload = (ev) => {
-          const img = { id: `drop-${Date.now()}`, url: ev.target?.result, file };
-          setImages((prev) => [img, ...prev]);
+          const img = { id: `drop-${Date.now()}`, url: ev.target?.result, file, type: 'image' };
+          setOutputs((prev) => [img, ...prev]);
           showToast('Image dropped, starting img2img...', 'info');
           if (prompt.trim()) handleGenerate();
         };
@@ -325,18 +334,19 @@ const CreatePage = () => {
       <h2 className="yesterday-header">Yesterday</h2>
       
       <div className="image-grid">
-        {images.map(image => (
-          <div key={image.id} className="image-card" onClick={() => handleImageClick(image)}>
-            <img 
-              src={image.url} 
-              alt={image.prompt} 
-              className="grid-image"
-              loading="lazy"
-            />
+        {outputs.map(out => (
+          <div key={out.id} className="image-card" onClick={() => handleImageClick(out)}>
+            {out.type === 'video' ? (
+              <video src={out.url} className="grid-image" controls preload="metadata" />
+            ) : out.type === 'model' ? (
+              <model-viewer src={out.url} class="grid-image" auto-rotate camera-controls></model-viewer>
+            ) : (
+              <img src={out.url} alt={out.prompt} className="grid-image" loading="lazy" />
+            )}
             <div className="image-overlay">
-              <div className="image-prompt">{image.prompt.substring(0, 100)}...</div>
+              <div className="image-prompt">{out.prompt.substring(0, 100)}...</div>
               <div className="image-metadata">
-                {image.metadata && Object.entries(image.metadata).map(([key, value]) => (
+                {out.metadata && Object.entries(out.metadata).map(([key, value]) => (
                   <span key={key} className="metadata-tag">
                     {key === 'chaos' && '🔄'}
                     {key === 'v' && '📏'}

--- a/frontend/src/pages/ParametersPage.js
+++ b/frontend/src/pages/ParametersPage.js
@@ -17,6 +17,7 @@ const ParametersPage = () => {
     node_id: "",
     param_name: "",
     value_template: "",
+    injection_mode: "",
     description: ""
   });
   
@@ -147,6 +148,7 @@ const ParametersPage = () => {
         node_id: "",
         param_name: "",
         value_template: "",
+        injection_mode: "",
         description: ""
       });
       
@@ -177,6 +179,7 @@ const ParametersPage = () => {
       node_id: parameter.node_id,
       param_name: parameter.param_name,
       value_template: parameter.value_template || "",
+      injection_mode: parameter.injection_mode || "",
       description: parameter.description || ""
     });
     
@@ -307,16 +310,30 @@ const ParametersPage = () => {
           <div className="form-group">
             <label htmlFor="value_template">Value Template</label>
             <div className="input-with-help">
-              <input 
-                type="text" 
-                id="value_template" 
+              <input
+                type="text"
+                id="value_template"
                 name="value_template"
                 value={newParameter.value_template}
                 onChange={handleParameterChange}
-                placeholder="e.g., width:height or {value}" 
+                placeholder="e.g., width:height or {value}"
               />
               <span className="help-text">Format for the parameter value (e.g., width:height for --ar 16:9)</span>
             </div>
+          </div>
+
+          <div className="form-group">
+            <label htmlFor="injection_mode">Injection Mode</label>
+            <select
+              id="injection_mode"
+              name="injection_mode"
+              value={newParameter.injection_mode}
+              onChange={handleParameterChange}
+            >
+              <option value="">None (set parameter)</option>
+              <option value="prepend">Prepend text</option>
+              <option value="append">Append text</option>
+            </select>
           </div>
           
           <div className="form-group">
@@ -373,6 +390,12 @@ const ParametersPage = () => {
                 <strong>Extracted Parameters:</strong>
                 <pre>{JSON.stringify(testResult.parameters, null, 2)}</pre>
               </div>
+              {testResult.injections && (
+                <div className="result-item">
+                  <strong>Text Injections:</strong>
+                  <pre>{JSON.stringify(testResult.injections, null, 2)}</pre>
+                </div>
+              )}
             </div>
           )}
         </div>
@@ -393,6 +416,7 @@ const ParametersPage = () => {
                 <th>Node</th>
                 <th>Parameter</th>
                 <th>Template</th>
+                <th>Injection</th>
                 <th>Description</th>
                 <th>Actions</th>
               </tr>
@@ -404,6 +428,7 @@ const ParametersPage = () => {
                   <td>{param.node_id}</td>
                   <td>{param.param_name}</td>
                   <td>{param.value_template || '{value}'}</td>
+                  <td>{param.injection_mode || '-'}</td>
                   <td>{param.description}</td>
                   <td className="parameter-actions">
                     <button 

--- a/frontend/src/services/actionService.js
+++ b/frontend/src/services/actionService.js
@@ -5,7 +5,7 @@ const API_URL = process.env.REACT_APP_BACKEND_URL;
 const getActions = async () => {
   try {
     const response = await authService.authAxios.get(`${API_URL}/api/relational/actions`);
-    return response.data;
+    return response.data?.payload || response.data;
   } catch (error) {
     console.error('Error getting actions:', error);
     return [];
@@ -15,7 +15,7 @@ const getActions = async () => {
 const createAction = async (action) => {
   try {
     const response = await authService.authAxios.post(`${API_URL}/api/relational/actions`, action);
-    return response.data;
+    return response.data?.payload || response.data;
   } catch (error) {
     console.error('Error creating action:', error);
     throw error;
@@ -25,7 +25,7 @@ const createAction = async (action) => {
 const updateAction = async (id, action) => {
   try {
     const response = await authService.authAxios.put(`${API_URL}/api/relational/actions/${id}`, action);
-    return response.data;
+    return response.data?.payload || response.data;
   } catch (error) {
     console.error('Error updating action:', error);
     throw error;
@@ -35,7 +35,7 @@ const updateAction = async (id, action) => {
 const deleteAction = async (id) => {
   try {
     const response = await authService.authAxios.delete(`${API_URL}/api/relational/actions/${id}`);
-    return response.data;
+    return response.data?.payload || response.data;
   } catch (error) {
     console.error('Error deleting action:', error);
     throw error;

--- a/frontend/src/services/parameterService.js
+++ b/frontend/src/services/parameterService.js
@@ -6,7 +6,7 @@ const API_URL = process.env.REACT_APP_BACKEND_URL;
 const getParameterMappings = async () => {
   try {
     const response = await authService.authAxios.get(`${API_URL}/api/parameters`);
-    return response.data;
+    return response.data?.payload || response.data;
   } catch (error) {
     console.error('Error getting parameter mappings:', error);
     throw error;
@@ -17,7 +17,7 @@ const getParameterMappings = async () => {
 const createParameterMapping = async (mapping) => {
   try {
     const response = await authService.authAxios.post(`${API_URL}/api/parameters`, mapping);
-    return response.data;
+    return response.data?.payload || response.data;
   } catch (error) {
     console.error('Error creating parameter mapping:', error);
     throw error;
@@ -28,7 +28,7 @@ const createParameterMapping = async (mapping) => {
 const updateParameterMapping = async (id, mapping) => {
   try {
     const response = await authService.authAxios.put(`${API_URL}/api/parameters/${id}`, mapping);
-    return response.data;
+    return response.data?.payload || response.data;
   } catch (error) {
     console.error('Error updating parameter mapping:', error);
     throw error;
@@ -39,7 +39,7 @@ const updateParameterMapping = async (id, mapping) => {
 const deleteParameterMapping = async (id) => {
   try {
     const response = await authService.authAxios.delete(`${API_URL}/api/parameters/${id}`);
-    return response.data;
+    return response.data?.payload || response.data;
   } catch (error) {
     console.error('Error deleting parameter mapping:', error);
     throw error;
@@ -49,37 +49,59 @@ const deleteParameterMapping = async (id) => {
 // Parse a prompt for parameter codes
 const parseParameterCodes = (prompt, parameterMappings) => {
   if (!prompt || !parameterMappings || !parameterMappings.length) {
-    return { cleanPrompt: prompt, parameters: {} };
+    return { cleanPrompt: prompt, parameters: {}, injections: [] };
   }
 
-  const paramCodeRegex = /--([a-zA-Z_]+)(?:[=\s]+(\"[^\"]*\"|'[^']*'|[^-\s]+))?/g;
-  let match;
+  const tokens = prompt.match(/\S+|"[^"]*"|'[^']*'/g) || [];
+  const remaining = [];
   const parameters = {};
-  let cleanPrompt = prompt;
+  const injections = [];
 
-  while ((match = paramCodeRegex.exec(prompt)) !== null) {
-    const [fullMatch, code, rawValue] = match;
-    const mapping = parameterMappings.find(p => p.code === `--${code}`);
-
-    if (mapping) {
-      let value = rawValue !== undefined ? rawValue.trim() : 'true';
-      if ((value.startsWith('"') && value.endsWith('"')) ||
-          (value.startsWith("'") && value.endsWith("'"))) {
-        value = value.slice(1, -1);
+  for (let i = 0; i < tokens.length; i++) {
+    let token = tokens[i];
+    if (token.startsWith('--')) {
+      let code = token.slice(2);
+      let value = null;
+      if (code.includes('=')) {
+        const parts = code.split('=');
+        code = parts.shift();
+        value = parts.join('=');
+      } else if (i + 1 < tokens.length && !tokens[i + 1].startsWith('--')) {
+        value = tokens[++i];
+        while (i + 1 < tokens.length && !tokens[i + 1].startsWith('--')) {
+          value += ' ' + tokens[++i];
+        }
+      } else {
+        value = 'true';
       }
-
-      parameters[mapping.node_id] = {
-        ...(parameters[mapping.node_id] || {}),
-        [mapping.param_name]: processValueTemplate(mapping.value_template, value)
-      };
-
-      cleanPrompt = cleanPrompt.replace(fullMatch, '').trim();
+      value = value.replace(/^['"]|['"]$/g, '');
+      const mapping = parameterMappings.find(p => p.code === `--${code}`);
+      if (mapping) {
+        if (mapping.injection_mode) {
+          injections.push({
+            node_id: mapping.node_id,
+            param_name: mapping.param_name,
+            mode: mapping.injection_mode,
+            value
+          });
+        } else {
+          parameters[mapping.node_id] = {
+            ...(parameters[mapping.node_id] || {}),
+            [mapping.param_name]: processValueTemplate(mapping.value_template, value)
+          };
+        }
+        continue;
+      }
+      remaining.push(token);
+    } else {
+      remaining.push(token);
     }
   }
 
   return {
-    cleanPrompt: cleanPrompt.trim(),
-    parameters
+    cleanPrompt: remaining.join(' ').trim(),
+    parameters,
+    injections
   };
 };
 

--- a/frontend/src/services/workflowService.js
+++ b/frontend/src/services/workflowService.js
@@ -7,7 +7,7 @@ const API_URL = process.env.REACT_APP_BACKEND_URL;
 const getComfyUIWorkflows = async () => {
   try {
     const response = await authService.authAxios.get(`${API_URL}/api/comfyui/workflows`);
-    return response.data;
+    return response.data?.payload || response.data;
   } catch (error) {
     console.error('Error getting ComfyUI workflows:', error);
     return [];
@@ -18,7 +18,7 @@ const getComfyUIWorkflows = async () => {
 const getWorkflows = async () => {
   try {
     const response = await authService.authAxios.get(`${API_URL}/api/relational/workflows`);
-    return response.data;
+    return response.data?.payload || response.data;
   } catch (error) {
     console.error('Error getting workflow mappings:', error);
     return [];
@@ -29,7 +29,7 @@ const getWorkflows = async () => {
 const createWorkflow = async (workflow) => {
   try {
     const response = await authService.authAxios.post(`${API_URL}/api/relational/workflows`, workflow);
-    return response.data;
+    return response.data?.payload || response.data;
   } catch (error) {
     console.error('Error creating workflow mapping:', error);
     throw error;
@@ -40,7 +40,7 @@ const createWorkflow = async (workflow) => {
 const updateWorkflow = async (id, workflow) => {
   try {
     const response = await authService.authAxios.put(`${API_URL}/api/relational/workflows/${id}`, workflow);
-    return response.data;
+    return response.data?.payload || response.data;
   } catch (error) {
     console.error('Error updating workflow mapping:', error);
     throw error;
@@ -51,7 +51,7 @@ const updateWorkflow = async (id, workflow) => {
 const deleteWorkflow = async (id) => {
   try {
     const response = await authService.authAxios.delete(`${API_URL}/api/relational/workflows/${id}`);
-    return response.data;
+    return response.data?.payload || response.data;
   } catch (error) {
     console.error('Error deleting workflow mapping:', error);
     throw error;


### PR DESCRIPTION
## Summary
- allow parameter mappings to specify injection mode
- support text injection operations in prompt parser
- return payload objects in client services
- add injection mode UI and test results on Parameter Manager page
- show image, video or model outputs on Create page

## Testing
- `pytest tests -q`

------
https://chatgpt.com/codex/tasks/task_b_683e38182aac8329a38dda38f3a8f726