### PR TITLE
Add parameter selector integration

### DIFF
--- a/frontend/src/components/NodeParameterSelector.js
+++ b/frontend/src/components/NodeParameterSelector.js
@@ -1,0 +1,107 @@
+import React, { useState, useEffect } from 'react';
+import { useNavigate } from 'react-router-dom';
+import workflowService from '../services/workflowService';
+
+const NodeParameterSelector = () => {
+  const [workflows, setWorkflows] = useState([]);
+  const [selectedWorkflow, setSelectedWorkflow] = useState('');
+  const [workflowNodes, setWorkflowNodes] = useState([]);
+  const [workflowNodeParameters, setWorkflowNodeParameters] = useState({});
+  const [nodeId, setNodeId] = useState('');
+  const [paramName, setParamName] = useState('');
+  const navigate = useNavigate();
+
+  useEffect(() => {
+    const fetchData = async () => {
+      try {
+        const wfs = await workflowService.getWorkflows();
+        setWorkflows(wfs);
+        if (wfs.length > 0) {
+          setSelectedWorkflow(wfs[0].id);
+          extractNodes(wfs[0]);
+        }
+      } catch (err) {
+        console.error('Failed to load workflows', err);
+      }
+    };
+    fetchData();
+  }, []);
+
+  const extractNodes = (workflow) => {
+    if (!workflow || !workflow.data || !workflow.data.nodes) {
+      setWorkflowNodes([]);
+      setWorkflowNodeParameters({});
+      return;
+    }
+    const nodes = [];
+    const nodeParams = {};
+    Object.entries(workflow.data.nodes).forEach(([id, node]) => {
+      nodes.push({ id, title: node.title || `Node ${id}`, type: node.type || 'Unknown' });
+      if (node.properties && Object.keys(node.properties).length > 0) {
+        nodeParams[id] = Object.keys(node.properties).map((p) => ({ name: p, type: typeof node.properties[p] }));
+      }
+    });
+    setWorkflowNodes(nodes);
+    setWorkflowNodeParameters(nodeParams);
+  };
+
+  const handleWorkflowChange = (e) => {
+    const id = e.target.value;
+    setSelectedWorkflow(id);
+    const wf = workflows.find((w) => w.id === id);
+    if (wf) {
+      extractNodes(wf);
+      setNodeId('');
+      setParamName('');
+    }
+  };
+
+  const handleCreate = () => {
+    if (selectedWorkflow && nodeId && paramName) {
+      navigate(`/parameters?workflow=${selectedWorkflow}&node=${nodeId}&param=${paramName}`);
+    }
+  };
+
+  return (
+    <div className="node-parameter-selector">
+      <h3>Select Node Parameter</h3>
+      <div className="selector-field">
+        <label>Workflow</label>
+        <select value={selectedWorkflow} onChange={handleWorkflowChange}>
+          {workflows.map((wf) => (
+            <option key={wf.id} value={wf.id}>
+              {wf.name || `Workflow ${wf.id}`}
+            </option>
+          ))}
+        </select>
+      </div>
+      <div className="selector-field">
+        <label>Node</label>
+        <select value={nodeId} onChange={(e) => { setNodeId(e.target.value); setParamName(''); }}>
+          <option value="">Select a node</option>
+          {workflowNodes.map((node) => (
+            <option key={node.id} value={node.id}>
+              {node.title} ({node.type})
+            </option>
+          ))}
+        </select>
+      </div>
+      <div className="selector-field">
+        <label>Parameter</label>
+        <select value={paramName} onChange={(e) => setParamName(e.target.value)} disabled={!nodeId}>
+          <option value="">Select a parameter</option>
+          {nodeId && workflowNodeParameters[nodeId]?.map((p) => (
+            <option key={p.name} value={p.name}>
+              {p.name}
+            </option>
+          ))}
+        </select>
+      </div>
+      <button onClick={handleCreate} disabled={!selectedWorkflow || !nodeId || !paramName}>
+        Create Shortcode
+      </button>
+    </div>
+  );
+};
+
+export default NodeParameterSelector;

--- a/frontend/src/pages/BackendManagerPage.js
+++ b/frontend/src/pages/BackendManagerPage.js
@@ -1,11 +1,22 @@
-import React from 'react';
+import React, { useState } from 'react';
 import ComfyUIEditor from '../components/ComfyUIEditor';
+import NodeParameterSelector from '../components/NodeParameterSelector';
 
 const BackendManagerPage = () => {
+  const [showSelector, setShowSelector] = useState(false);
+
   return (
     <div className="backend-manager-page">
       <h1>Backend Manager</h1>
       <p>Manage your local ComfyUI instance directly.</p>
+      <button className="open-selector-button" onClick={() => setShowSelector(!showSelector)}>
+        {showSelector ? 'Close Parameter Selector' : 'Select Node Parameter'}
+      </button>
+      {showSelector && (
+        <div className="selector-panel">
+          <NodeParameterSelector />
+        </div>
+      )}
       <ComfyUIEditor />
     </div>
   );

--- a/frontend/src/pages/ParametersPage.js
+++ b/frontend/src/pages/ParametersPage.js
@@ -1,4 +1,5 @@
 import React, { useState, useEffect } from 'react';
+import { useLocation } from 'react-router-dom';
 import { useAuth } from '../contexts/AuthContext';
 import Toast from '../components/Toast';
 import parameterService from '../services/parameterService';
@@ -11,7 +12,7 @@ const ParametersPage = () => {
   const [selectedWorkflow, setSelectedWorkflow] = useState(null);
   const [workflowNodes, setWorkflowNodes] = useState([]);
   const [workflowNodeParameters, setWorkflowNodeParameters] = useState({});
-  
+
   const [newParameter, setNewParameter] = useState({
     code: "",
     node_id: "",
@@ -20,8 +21,9 @@ const ParametersPage = () => {
     injection_mode: "",
     description: ""
   });
-  
+
   const [toast, setToast] = useState(null);
+  const location = useLocation();
   const { currentUser } = useAuth();
   
   useEffect(() => {
@@ -53,6 +55,25 @@ const ParametersPage = () => {
     
     fetchData();
   }, []);
+
+  useEffect(() => {
+    if (workflows.length === 0) return;
+    const query = new URLSearchParams(location.search);
+    const wfId = query.get('workflow');
+    const nodeId = query.get('node');
+    const param = query.get('param');
+    if (wfId) {
+      const wf = workflows.find((w) => w.id === wfId) || workflows[0];
+      setSelectedWorkflow(wf.id);
+      extractWorkflowNodes(wf);
+      if (nodeId) {
+        setNewParameter((prev) => ({ ...prev, node_id: nodeId }));
+      }
+      if (param) {
+        setNewParameter((prev) => ({ ...prev, param_name: param }));
+      }
+    }
+  }, [workflows, location.search]);
   
   const extractWorkflowNodes = (workflow) => {
     if (!workflow || !workflow.data || !workflow.data.nodes) {


### PR DESCRIPTION
## Summary
- add **NodeParameterSelector** component to choose workflow nodes and parameters
- link NodeParameterSelector from Backend page with a toggleable panel
- prefill Parameter Manager form when opened with workflow/node/parameter query params

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'torch' and other missing modules)*

------
https://chatgpt.com/codex/tasks/task_b_683e48e6597c8329b7e62a76b51d1b0d