### PR TITLE
Optimize civitai client and configure pytest

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,3 @@
+[pytest]
+testpaths = tests
+addopts = -p no:warnings


### PR DESCRIPTION
## Summary
- cache `httpx.AsyncClient` in `civitai.py` to cut connection overhead
- reset the cached client when the cache is cleared for tests
- add `pytest.ini` so only our tests are collected

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_683e5dd0a9148329987b2bc253553931