### PR TITLE
Fix Civitai explore API and improve backend page

### DIFF
--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -1304,3 +1304,25 @@ button:disabled {
 .gallery-overlay button:hover {
   background: var(--mj-accent-hover);
 }
+
+/* ComfyUI backend iframe styles */
+.comfyui-editor-container {
+  display: flex;
+  flex-direction: column;
+  height: calc(100vh - 80px);
+}
+
+.comfyui-editor-container.fullscreen {
+  position: fixed;
+  inset: 0;
+  z-index: 1000;
+  background: var(--bg-dark);
+}
+
+.comfyui-editor-frame,
+.comfyui-iframe {
+  flex: 1;
+  width: 100%;
+  height: 100%;
+  border: none;
+}

--- a/frontend/src/pages/CreatePage.js
+++ b/frontend/src/pages/CreatePage.js
@@ -68,9 +68,6 @@ const CreatePage = () => {
     return () => window.removeEventListener('keydown', handleKeyDown);
   }, [prevPrompt, nextPrompt]);
 
-  // Categories for the tabs
-  const categories = ['Random', 'Hot', 'Top Month', 'Likes'];
-  const [activeCategory, setActiveCategory] = useState('Hot');
 
   // Fetch parameter mappings on component mount
   useEffect(() => {
@@ -336,19 +333,6 @@ const CreatePage = () => {
           </div>
         </div>
       </div>
-
-      <div className="category-tabs">
-        {categories.map(category => (
-          <button
-            key={category}
-            className={`category-tab ${activeCategory === category ? 'active' : ''}`}
-            onClick={() => setActiveCategory(category)}
-          >
-            {category}
-          </button>
-        ))}
-      </div>
-
       <div className="search-container" style={{ marginTop: '10px' }}>
         <input
           type="text"

--- a/frontend/src/services/civitaiService.js
+++ b/frontend/src/services/civitaiService.js
@@ -37,12 +37,13 @@ const makeRequest = async (endpoint, params = {}) => {
   
   try {
     const response = await fetch(url.toString(), options);
-    
+
     if (!response.ok) {
       throw new Error(`API error: ${response.status}`);
     }
-    
-    return await response.json();
+
+    const data = await response.json();
+    return data.payload !== undefined ? data.payload : data;
   } catch (error) {
     console.error('Civitai API error:', error);
     throw error;


### PR DESCRIPTION
## Summary
- remove category tabs from the Create page
- unwrap payloads from backend in `civitaiService`
- style backend iframe so it fills the page and fullscreen works

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_683e9715130483299dd57151a5a21706