### PR TITLE
Add logging system and remove emergent badge

### DIFF
--- a/frontend/public/index.html
+++ b/frontend/public/index.html
@@ -33,52 +33,6 @@
       To begin the development, run `npm start` or `yarn start`.
       To create a production bundle, use `npm run build` or `yarn build`.
     -->
-        <a
-            id="emergent-badge"
-            target="_blank"
-            href="https://app.emergent.sh/?utm_source=emergent-badge"
-            style="
-                display: flex !important;
-                align-items: center !important;
-                position: fixed !important;
-                bottom: 20px;
-                right: 20px;
-                text-decoration: none;
-                padding: 6px 10px;
-                font-family: -apple-system, BlinkMacSystemFont,
-                    &quot;Segoe UI&quot;, Roboto, Oxygen, Ubuntu, Cantarell,
-                    &quot;Open Sans&quot;, &quot;Helvetica Neue&quot;,
-                    sans-serif !important;
-                font-size: 12px !important;
-                z-index: 9999 !important;
-                box-shadow: 0 2px 8px rgba(0, 0, 0, 0.15) !important;
-                border-radius: 8px !important;
-                background-color: #ffffff !important;
-                border: 1px solid rgba(255, 255, 255, 0.25) !important;
-            "
-        >
-            <div
-                style="display: flex; flex-direction: row; align-items: center"
-            >
-                <img
-                    style="width: 20px; height: 20px; margin-right: 8px"
-                    src="https://avatars.githubusercontent.com/in/1201222?s=120&u=2686cf91179bbafbc7a71bfbc43004cf9ae1acea&v=4"
-                />
-                <p
-                    style="
-                        color: #000000;
-                        font-family: -apple-system, BlinkMacSystemFont,
-                            &quot;Segoe UI&quot;, Roboto, Oxygen, Ubuntu,
-                            Cantarell, &quot;Open Sans&quot;,
-                            &quot;Helvetica Neue&quot;, sans-serif !important;
-                        font-size: 12px !important;
-                        align-items: center;
-                        margin-bottom: 0;
-                    "
-                >
-                    Made with Emergent
-                </p>
-            </div>
-        </a>
+
     </body>
 </html>

--- a/frontend/src/components/ErrorBoundary.js
+++ b/frontend/src/components/ErrorBoundary.js
@@ -1,4 +1,5 @@
 import React, { Component } from 'react';
+import loggingService from '../services/loggingService';
 
 class ErrorBoundary extends Component {
   constructor(props) {
@@ -18,6 +19,10 @@ class ErrorBoundary extends Component {
   componentDidCatch(error, errorInfo) {
     // Log the error to an error reporting service
     console.error('Error caught by boundary:', error, errorInfo);
+    loggingService.logFrontend({
+      message: error.toString(),
+      stack: errorInfo.componentStack,
+    });
     this.setState({
       error: error,
       errorInfo: errorInfo

--- a/frontend/src/index.js
+++ b/frontend/src/index.js
@@ -3,6 +3,7 @@ import ReactDOM from "react-dom/client";
 import "./index.css";
 import "./midjourney-theme.css"; // Import the Midjourney-style theme
 import App from "./App";
+import ErrorBoundary from "./components/ErrorBoundary";
 
 // Apply saved theme preference before rendering
 try {
@@ -17,6 +18,8 @@ try {
 const root = ReactDOM.createRoot(document.getElementById("root"));
 root.render(
   <React.StrictMode>
-    <App />
+    <ErrorBoundary>
+      <App />
+    </ErrorBoundary>
   </React.StrictMode>,
 );

--- a/frontend/src/services/loggingService.js
+++ b/frontend/src/services/loggingService.js
@@ -1,0 +1,13 @@
+import axios from 'axios';
+
+const API_URL = process.env.REACT_APP_BACKEND_URL;
+
+const logFrontend = async (payload) => {
+  try {
+    await axios.post(`${API_URL}/api/logs/frontend`, payload);
+  } catch (err) {
+    console.error('Failed to send frontend log', err);
+  }
+};
+
+export default { logFrontend };


### PR DESCRIPTION
## Summary
- log backend and frontend events to separate files in new `logs` directory
- expose `/api/logs/frontend` endpoint for browser error logging
- capture errors via ErrorBoundary and send to backend
- wire ErrorBoundary in `index.js`
- remove Emergent badge from landing page

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_683e9cb5d0808329bae85d45762927f4