### PR TITLE
Fix workflow picker and comfyui check

### DIFF
--- a/frontend/src/components/ComfyUIEditor.js
+++ b/frontend/src/components/ComfyUIEditor.js
@@ -17,15 +17,15 @@ const ComfyUIEditor = () => {
   const checkConnection = async () => {
     setStatus("loading");
     try {
-      // Try to fetch the status endpoint
-      const response = await fetch(`${comfyuiUrl}/system_stats`);
-      if (response.ok) {
+      // Use backend proxy to avoid CORS issues when checking status
+      const resp = await fetch("/api/comfyui/status");
+      const data = await resp.json();
+      if (data?.payload?.status === "online") {
         setStatus("connected");
         return true;
-      } else {
-        setStatus("disconnected");
-        return false;
       }
+      setStatus("disconnected");
+      return false;
     } catch (error) {
       console.error("Error checking ComfyUI connection:", error);
       setStatus("disconnected");

--- a/frontend/src/pages/WorkflowsPage.js
+++ b/frontend/src/pages/WorkflowsPage.js
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from 'react';
+import React, { useState, useEffect, useRef } from 'react';
 import { useAuth } from '../contexts/AuthContext';
 import Toast from '../components/Toast';
 import workflowService from '../services/workflowService';
@@ -15,6 +15,7 @@ const WorkflowsPage = () => {
     description: '',
     file: null
   });
+  const fileInputRef = useRef(null);
   
   // For action mappings
   const [actionMappings, setActionMappings] = useState({
@@ -105,6 +106,10 @@ const WorkflowsPage = () => {
       ...newWorkflow,
       file: e.target.files[0]
     });
+  };
+
+  const handleBrowseClick = () => {
+    fileInputRef.current?.click();
   };
   
   const handleAddWorkflow = async () => {
@@ -351,14 +356,15 @@ const WorkflowsPage = () => {
             <div className="form-group">
               <label htmlFor="workflowFile">Workflow File</label>
               <div className="file-input-container">
-                <button className="browse-button">Browse...</button>
+                <button className="browse-button" onClick={handleBrowseClick}>Browse...</button>
                 <span className="file-name">{newWorkflow.file ? newWorkflow.file.name : 'No file selected.'}</span>
-                <input 
-                  type="file" 
-                  id="workflowFile" 
+                <input
+                  type="file"
+                  id="workflowFile"
+                  ref={fileInputRef}
                   onChange={handleFileChange}
                   className="hidden-file-input"
-                  accept=".json" 
+                  accept=".json"
                 />
               </div>
             </div>
@@ -402,7 +408,7 @@ const WorkflowsPage = () => {
                 <select
                   className="workflow-select"
                   onChange={(e) => handleUpdateActionMapping(actionName, e.target.value)}
-                  value={workflows.find(w => w.name === action.assigned)?.id || ''}
+                  value={action.workflow_id || ''}
                 >
                   <option value="">Select Workflow</option>
                   {workflows.map(workflow => (


### PR DESCRIPTION
## Summary
- use backend status endpoint when connecting to ComfyUI
- trigger workflow file picker via browse button
- keep workflow dropdown bound to workflow_id

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_683e9f80d3348329a661bdca88e82089