### PR TITLE
Fix ComfyUI connection handling and logging

### DIFF
--- a/backend/server.py
+++ b/backend/server.py
@@ -618,39 +618,85 @@ async def progress_stream(request: Request, job_id: str):
 
 @api_router.post("/comfyui/prompt")
 async def proxy_comfyui_prompt(payload: Dict[str, Any]):
+    """Proxy prompt submission to the ComfyUI backend."""
     start = datetime.utcnow().timestamp()
-    resp = requests.post(f"{COMFYUI_BASE_URL}/prompt", json=payload)
-    data = resp.json()
-    log_backend_call("POST", f"{COMFYUI_BASE_URL}/prompt", payload, data, resp.status_code, start)
-    return api_response(data)
+    try:
+        resp = requests.post(f"{COMFYUI_BASE_URL}/prompt", json=payload, timeout=30)
+        data = resp.json()
+        log_backend_call("POST", f"{COMFYUI_BASE_URL}/prompt", payload, data, resp.status_code, start)
+        return api_response(data)
+    except Exception as exc:
+        log_backend_call(
+            "POST",
+            f"{COMFYUI_BASE_URL}/prompt",
+            payload,
+            {"error": str(exc)},
+            500,
+            start,
+        )
+        return api_response(None, success=False, error=str(exc))
 
 
 @api_router.get("/comfyui/history")
 async def proxy_comfyui_history():
+    """Proxy generation history from ComfyUI."""
     start = datetime.utcnow().timestamp()
-    resp = requests.get(f"{COMFYUI_BASE_URL}/history")
-    data = resp.json()
-    log_backend_call("GET", f"{COMFYUI_BASE_URL}/history", None, data, resp.status_code, start)
-    return api_response(data)
+    try:
+        resp = requests.get(f"{COMFYUI_BASE_URL}/history", timeout=30)
+        data = resp.json()
+        log_backend_call("GET", f"{COMFYUI_BASE_URL}/history", None, data, resp.status_code, start)
+        return api_response(data)
+    except Exception as exc:
+        log_backend_call(
+            "GET",
+            f"{COMFYUI_BASE_URL}/history",
+            None,
+            {"error": str(exc)},
+            500,
+            start,
+        )
+        return api_response(None, success=False, error=str(exc))
 
 
 @api_router.get("/comfyui/queue")
 async def proxy_comfyui_queue():
+    """Proxy queue state from ComfyUI."""
     start = datetime.utcnow().timestamp()
-    resp = requests.get(f"{COMFYUI_BASE_URL}/queue")
-    data = resp.json()
-    log_backend_call("GET", f"{COMFYUI_BASE_URL}/queue", None, data, resp.status_code, start)
-    return api_response(data)
+    try:
+        resp = requests.get(f"{COMFYUI_BASE_URL}/queue", timeout=30)
+        data = resp.json()
+        log_backend_call("GET", f"{COMFYUI_BASE_URL}/queue", None, data, resp.status_code, start)
+        return api_response(data)
+    except Exception as exc:
+        log_backend_call(
+            "GET",
+            f"{COMFYUI_BASE_URL}/queue",
+            None,
+            {"error": str(exc)},
+            500,
+            start,
+        )
+        return api_response(None, success=False, error=str(exc))
 
 
 @api_router.get("/comfyui/status")
 async def comfyui_status():
     """Return basic status information about the configured ComfyUI server."""
+    start = datetime.utcnow().timestamp()
     try:
         resp = requests.get(f"{COMFYUI_BASE_URL}/queue", timeout=5)
         resp.raise_for_status()
+        log_backend_call("GET", f"{COMFYUI_BASE_URL}/queue", None, {"status": "ok"}, resp.status_code, start)
         return api_response({"status": "online"})
     except Exception as exc:  # pragma: no cover - network failures
+        log_backend_call(
+            "GET",
+            f"{COMFYUI_BASE_URL}/queue",
+            None,
+            {"error": str(exc)},
+            500,
+            start,
+        )
         return api_response({"status": "offline", "error": str(exc)})
 
 

--- a/tests/test_comfyui_errors.py
+++ b/tests/test_comfyui_errors.py
@@ -1,0 +1,79 @@
+import os
+import sys
+import types
+import json
+import importlib
+from fastapi.testclient import TestClient
+
+# Ensure stubbed motor client for DB
+os.environ["DATABASE_URL"] = "sqlite:///./test.db"
+os.environ["DISABLE_CSRF"] = "true"
+
+motor_module = types.ModuleType("motor")
+motor_asyncio = types.ModuleType("motor.motor_asyncio")
+
+class DummyClient:
+    def __init__(self, *args, **kwargs):
+        pass
+    def get_database(self, name):
+        class DummyCollection:
+            def __init__(self):
+                self.data = {}
+            async def insert_one(self, doc):
+                self.data[doc.get("_id")] = doc
+            def find(self):
+                class Cursor:
+                    def __init__(self, data):
+                        self.data = data
+                    async def to_list(self, limit):
+                        return list(self.data.values())
+                return Cursor(self.data)
+            async def update_one(self, filt, update, upsert=False):
+                _id = filt.get("_id")
+                doc = self.data.get(_id, {})
+                doc.update(update.get("$set", {}))
+                self.data[_id] = doc
+            async def delete_one(self, filt):
+                self.data.pop(filt.get("_id"), None)
+            async def find_one(self, filt):
+                return self.data.get(filt.get("_id"))
+        return types.SimpleNamespace(
+            parameter_mappings=DummyCollection(),
+            workflow_mappings=DummyCollection(),
+            action_mappings=DummyCollection(),
+            civitai_key=DummyCollection(),
+        )
+
+motor_asyncio.AsyncIOMotorClient = DummyClient
+sys.modules["motor"] = motor_module
+sys.modules["motor.motor_asyncio"] = motor_asyncio
+
+
+def test_comfyui_error_logging(tmp_path, monkeypatch):
+    os.environ["LOGS_DIR"] = str(tmp_path)
+    # Reload modules so LOGS_DIR takes effect
+    import backend.utils as utils
+    importlib.reload(utils)
+    import backend.server as server
+    importlib.reload(server)
+
+    client = TestClient(server.app)
+
+    def fail_post(*args, **kwargs):
+        raise RuntimeError("connection failed")
+
+    monkeypatch.setattr(server.requests, "post", fail_post)
+
+    resp = client.post("/api/comfyui/prompt", json={"prompt": "test"})
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["success"] is False
+
+    log_path = tmp_path / "log_backend.txt"
+    assert log_path.exists()
+    with open(log_path, "r", encoding="utf-8") as fh:
+        lines = fh.readlines()
+    assert lines
+    entry = json.loads(lines[-1])
+    assert entry["method"] == "POST"
+    assert entry["status"] == 500


### PR DESCRIPTION
## Summary
- handle connection errors when proxying to ComfyUI backend
- log failed attempts to `logs/log_backend.txt`
- add regression test ensuring failures are logged

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_683eba2c4cd88329a7d83bd3235943ac