### PR TITLE
Implement NSFW toggle for Civitai

### DIFF
--- a/backend/server.py
+++ b/backend/server.py
@@ -718,9 +718,15 @@ async def has_civitai_key():
 
 
 @api_router.get("/civitai/images")
-async def civitai_images(limit: int = 20, page: int = 1, query: Optional[str] = None):
+async def civitai_images(
+    limit: int = 20,
+    page: int = 1,
+    query: Optional[str] = None,
+    nsfw: Optional[bool] = False,
+):
+    """Proxy to Civitai image search with optional NSFW flag."""
     api_key = await get_civitai_key()
-    params = {"limit": limit, "page": page}
+    params = {"limit": limit, "page": page, "nsfw": nsfw}
     if query:
         params["query"] = query
     data = await civitai_fetch("/images", params=params, api_key=api_key)
@@ -728,11 +734,19 @@ async def civitai_images(limit: int = 20, page: int = 1, query: Optional[str] = 
 
 
 @api_router.get("/civitai/models")
-async def civitai_models(limit: int = 20, page: int = 1, query: Optional[str] = None):
+async def civitai_models(
+    limit: int = 20,
+    page: int = 1,
+    query: Optional[str] = None,
+    types: Optional[str] = None,
+):
+    """Proxy to Civitai model search with optional type filter."""
     api_key = await get_civitai_key()
     params = {"limit": limit, "page": page}
     if query:
         params["query"] = query
+    if types:
+        params["types"] = types
     data = await civitai_fetch("/models", params=params, api_key=api_key)
     return api_response(data)
 

--- a/frontend/src/pages/ExplorePage.js
+++ b/frontend/src/pages/ExplorePage.js
@@ -7,6 +7,10 @@ import downloadService from '../services/downloadService';
 
 const ExplorePage = () => {
   const [activeTab, setActiveTab] = useState('Images');
+  const [showNsfw, setShowNsfw] = useState(() => {
+    const saved = localStorage.getItem('cj_civitai_show_nsfw');
+    return saved === 'true';
+  });
   const [images, setImages] = useState([]);
   const [models, setModels] = useState([]);
   const [workflows, setWorkflows] = useState([]);
@@ -26,6 +30,11 @@ const ExplorePage = () => {
   const categories = ['Random', 'Hot', 'Top Month', 'Likes'];
   const [activeCategory, setActiveCategory] = useState('Top Month');
 
+  // Persist NSFW preference
+  useEffect(() => {
+    localStorage.setItem('cj_civitai_show_nsfw', showNsfw.toString());
+  }, [showNsfw]);
+
   // Fetch images and models when the page changes
   useEffect(() => {
     const fetchExploreData = async () => {
@@ -36,7 +45,7 @@ const ExplorePage = () => {
           setLoadingMore(true);
         }
 
-        const imagesRes = await civitaiService.getImages({ limit: 20, page });
+        const imagesRes = await civitaiService.getImages({ limit: 20, page, nsfw: showNsfw });
         const modelsRes = await civitaiService.getModels({ limit: 20, page });
         const workflowsRes = await civitaiService.getModels({ limit: 20, page, types: 'Workflow' });
 
@@ -74,7 +83,7 @@ const ExplorePage = () => {
     };
 
     fetchExploreData();
-  }, [page]);
+  }, [page, showNsfw]);
 
   // Observer to trigger loading more images when scrolling near the bottom
   useEffect(() => {

--- a/frontend/src/pages/SettingsPage.js
+++ b/frontend/src/pages/SettingsPage.js
@@ -25,6 +25,10 @@ const SettingsPage = () => {
   });
 
   const [civitaiKey, setCivitaiKey] = useState('');
+  const [civitaiShowNsfw, setCivitaiShowNsfw] = useState(() => {
+    const saved = localStorage.getItem('cj_civitai_show_nsfw');
+    return saved === 'true';
+  });
   const [restoreFile, setRestoreFile] = useState(null);
 
   const [paths, setPaths] = useState({
@@ -76,6 +80,11 @@ const SettingsPage = () => {
       document.body.classList.add('light-theme');
     }
   }, [preferences.darkMode]);
+
+  // Persist NSFW preference
+  useEffect(() => {
+    localStorage.setItem('cj_civitai_show_nsfw', civitaiShowNsfw.toString());
+  }, [civitaiShowNsfw]);
   
   const handleProfileChange = (e) => {
     const { name, value } = e.target;
@@ -424,6 +433,16 @@ const SettingsPage = () => {
                     onChange={(e) => setCivitaiKey(e.target.value)}
                   />
                   <button className="save-button" onClick={handleSaveCivitaiKey}>Save</button>
+                </div>
+                <div className="api-key-value" style={{ marginTop: '0.5rem' }}>
+                  <label className="toggle-label">
+                    <input
+                      type="checkbox"
+                      checked={civitaiShowNsfw}
+                      onChange={(e) => setCivitaiShowNsfw(e.target.checked)}
+                    />
+                    Show NSFW content
+                  </label>
                 </div>
               </div>
             </div>


### PR DESCRIPTION
## Summary
- extend Civitai backend endpoints with `nsfw` and `types`
- add SFW/NSFW toggle saved in Settings page
- respect toggle in Explore page image queries

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_683ebb5b69588329bb461ff77fc508d2