### PR TITLE
Fix backend connect & explore sorting

### DIFF
--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -1350,3 +1350,27 @@ button:disabled {
   height: 100%;
   border: none;
 }
+
+.backend-header {
+  position: relative;
+}
+
+.backend-header .status-indicator {
+  position: absolute;
+  top: 4px;
+  right: 0;
+}
+
+/* Status indicator for backend connection */
+.status-indicator {
+  display: inline-block;
+  width: 12px;
+  height: 12px;
+  border-radius: 50%;
+  background: var(--danger-color);
+  margin-left: 8px;
+}
+
+.status-indicator.online {
+  background: var(--success-color);
+}

--- a/frontend/src/pages/ExplorePage.js
+++ b/frontend/src/pages/ExplorePage.js
@@ -30,12 +30,19 @@ const ExplorePage = () => {
   const categories = ['Random', 'Hot', 'Top Month', 'Likes'];
   const [activeCategory, setActiveCategory] = useState('Top Month');
 
+  const categoryParams = {
+    Random: { sort: 'Newest', period: 'Week' },
+    Hot: { sort: 'Most Reactions', period: 'Day' },
+    'Top Month': { sort: 'Most Reactions', period: 'Month' },
+    Likes: { sort: 'Most Reactions', period: 'AllTime' }
+  };
+
   // Persist NSFW preference
   useEffect(() => {
     localStorage.setItem('cj_civitai_show_nsfw', showNsfw.toString());
   }, [showNsfw]);
 
-  // Fetch images and models when the page changes
+  // Fetch images and models when the page or category changes
   useEffect(() => {
     const fetchExploreData = async () => {
       try {
@@ -45,7 +52,8 @@ const ExplorePage = () => {
           setLoadingMore(true);
         }
 
-        const imagesRes = await civitaiService.getImages({ limit: 20, page, nsfw: showNsfw });
+        const { sort, period } = categoryParams[activeCategory] || {};
+        const imagesRes = await civitaiService.getImages({ limit: 20, page, nsfw: showNsfw, sort, period });
         const modelsRes = await civitaiService.getModels({ limit: 20, page });
         const workflowsRes = await civitaiService.getModels({ limit: 20, page, types: 'Workflow' });
 
@@ -83,7 +91,7 @@ const ExplorePage = () => {
     };
 
     fetchExploreData();
-  }, [page, showNsfw]);
+  }, [page, showNsfw, activeCategory]);
 
   // Observer to trigger loading more images when scrolling near the bottom
   useEffect(() => {

--- a/frontend/src/pages/SettingsPage.js
+++ b/frontend/src/pages/SettingsPage.js
@@ -420,7 +420,10 @@ const SettingsPage = () => {
 
           {activeTab === 'backend' && (
             <div className="settings-section">
-              <h2>Backend Connection</h2>
+              <h2 className="backend-header">
+                Backend Connection
+                <span className={`status-indicator ${connectionStatus === 'online' ? 'online' : ''}`}></span>
+              </h2>
               <div className="form-group">
                 <label htmlFor="comfyuiUrl">ComfyUI URL</label>
                 <input
@@ -432,7 +435,6 @@ const SettingsPage = () => {
                 />
                 <button className="save-button" onClick={handleConnectBackend}>Save</button>
               </div>
-              <p>Connection status: {connectionStatus}</p>
               <div className="form-group checkbox-group">
                 <input
                   type="checkbox"

--- a/frontend/src/services/authService.js
+++ b/frontend/src/services/authService.js
@@ -5,12 +5,16 @@ const API_URL = process.env.REACT_APP_BACKEND_URL;
 // Create an axios instance that includes the auth token in the header
 const authAxios = axios.create();
 
-// Add a request interceptor to include the auth token
+// Add a request interceptor to include the auth token and ComfyUI URL
 authAxios.interceptors.request.use(
   config => {
     const user = JSON.parse(localStorage.getItem('comfyui_user'));
     if (user && user.token) {
       config.headers['Authorization'] = `Bearer ${user.token}`;
+    }
+    const comfyUrl = localStorage.getItem('comfyuiUrl');
+    if (comfyUrl) {
+      config.headers['X-Comfyui-Url'] = comfyUrl;
     }
     return config;
   },


### PR DESCRIPTION
## Summary
- allow overriding the ComfyUI URL via `X-Comfyui-Url` header
- propagate the configured URL from the frontend via axios interceptor
- show connection indicator on the settings page
- hook explore page category tabs to Civitai query params

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_683ec43d76cc83298955c01a57d41fd7