### PR TITLE
Add videos tab and unified sort filters

### DIFF
--- a/backend/server.py
+++ b/backend/server.py
@@ -805,6 +805,17 @@ async def civitai_images(request: Request, limit: int = 20, page: int = 1):
     return api_response(data)
 
 
+@api_router.get("/civitai/videos")
+async def civitai_videos(request: Request, limit: int = 20, page: int = 1):
+    """Proxy to Civitai video search forwarding all query parameters."""
+    api_key = await get_civitai_key()
+    params = dict(request.query_params)
+    params.setdefault("limit", str(limit))
+    params.setdefault("page", str(page))
+    data = await civitai_fetch("/videos", params=params, api_key=api_key)
+    return api_response(data)
+
+
 @api_router.get("/civitai/models")
 async def civitai_models(request: Request, limit: int = 20, page: int = 1):
     """Proxy to Civitai model search forwarding all query parameters."""

--- a/frontend/src/services/civitaiService.js
+++ b/frontend/src/services/civitaiService.js
@@ -59,7 +59,8 @@ export const getImages = async ({
   period = 'AllTime',
   query = '',
   username = '',
-  modelId = ''
+  modelId = '',
+  baseModel = ''
 }) => {
   const params = {
     limit,
@@ -68,7 +69,8 @@ export const getImages = async ({
     sort,
     period,
     username,
-    modelId
+    modelId,
+    baseModel
   };
   
   // Add search query if provided (as a query parameter)
@@ -96,7 +98,8 @@ export const getModels = async ({
   tag = '',
   types = '',
   sort = 'Highest Rated',
-  period = 'AllTime'
+  period = 'AllTime',
+  baseModel = ''
 }) => {
   return makeRequest('/models', {
     limit,
@@ -105,8 +108,36 @@ export const getModels = async ({
     tag,
     types,
     sort,
-    period
+    period,
+    baseModel
   });
+};
+
+export const getVideos = async ({
+  limit = 20,
+  page = 1,
+  nsfw = false,
+  sort = 'Most Reactions',
+  period = 'AllTime',
+  query = '',
+  username = '',
+  modelId = '',
+  baseModel = ''
+}) => {
+  const params = {
+    limit,
+    page,
+    nsfw,
+    sort,
+    period,
+    username,
+    modelId,
+    baseModel
+  };
+  if (query) {
+    params.query = query;
+  }
+  return makeRequest('/videos', params);
 };
 
 // Get specific model
@@ -161,6 +192,7 @@ export const checkApiKey = async () => {
 
 export default {
   getImages,
+  getVideos,
   getTrendingImages,
   getModels,
   getModel,

--- a/tests/test_civitai_endpoints.py
+++ b/tests/test_civitai_endpoints.py
@@ -82,3 +82,25 @@ def test_query_parameters_forwarded(monkeypatch):
     assert captured["params"]["sort"] == "Newest"
     assert captured["params"]["period"] == "Week"
     assert captured["params"]["username"] == "bob"
+
+
+def test_videos_forwarded(monkeypatch):
+    captured = {}
+
+    async def dummy_fetch(endpoint, params=None, api_key=None):
+        captured["endpoint"] = endpoint
+        captured["params"] = params
+        return {}
+
+    monkeypatch.setattr(server, "civitai_fetch", dummy_fetch)
+
+    resp = client.get(
+        "/api/civitai/videos",
+        params={"limit": 3, "page": 1, "sort": "Newest", "period": "Month"},
+    )
+    assert resp.status_code == 200
+    assert captured["endpoint"] == "/videos"
+    assert captured["params"]["limit"] == "3"
+    assert captured["params"]["page"] == "1"
+    assert captured["params"]["sort"] == "Newest"
+    assert captured["params"]["period"] == "Month"


### PR DESCRIPTION
## Summary
- support new `/api/civitai/videos` endpoint
- extend civitaiService with getVideos and base model filters
- overhaul Explore page to include Videos tab and new filter/sort menu
- test query parameter forwarding for videos

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_683ed2b556a483299ef33b0da1f6d292