### PR TITLE
Fix backend API URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,8 @@ export COMFYUI_BASE_URL=http://localhost:8188
 export DATABASE_URL=sqlite:///./comfy.db
 export SECRET_KEY=change-me
 export CIVITAI_API_KEY=<your-key>
+# URL where the FastAPI backend is reachable
+export REACT_APP_BACKEND_URL=http://localhost:8001
 ```
 
 4. Start the application:

--- a/frontend/.env
+++ b/frontend/.env
@@ -1,2 +1,2 @@
 WDS_SOCKET_PORT=443
-REACT_APP_BACKEND_URL=https://ada1fbb6-a49a-40fa-a46e-2d13c2cd9eb8.preview.emergentagent.com
+REACT_APP_BACKEND_URL=http://localhost:8001

--- a/frontend/src/services/actionService.js
+++ b/frontend/src/services/actionService.js
@@ -1,6 +1,6 @@
 import authService from './authService';
 
-const API_URL = process.env.REACT_APP_BACKEND_URL || "";
+const API_URL = process.env.REACT_APP_BACKEND_URL || "http://localhost:8001";
 
 const getActions = async () => {
   try {

--- a/frontend/src/services/authService.js
+++ b/frontend/src/services/authService.js
@@ -1,6 +1,6 @@
 import axios from 'axios';
 
-const API_URL = process.env.REACT_APP_BACKEND_URL || "";
+const API_URL = process.env.REACT_APP_BACKEND_URL || "http://localhost:8001";
 
 // Create an axios instance that includes the auth token in the header
 const authAxios = axios.create();

--- a/frontend/src/services/backupService.js
+++ b/frontend/src/services/backupService.js
@@ -1,6 +1,6 @@
 import authService from './authService';
 
-const API_URL = process.env.REACT_APP_BACKEND_URL || "";
+const API_URL = process.env.REACT_APP_BACKEND_URL || "http://localhost:8001";
 
 const downloadBackup = async () => {
   const resp = await authService.authAxios.get(`${API_URL}/api/maintenance/backup`, {

--- a/frontend/src/services/downloadService.js
+++ b/frontend/src/services/downloadService.js
@@ -1,6 +1,6 @@
 import authService from './authService';
 
-const API_URL = process.env.REACT_APP_BACKEND_URL || "";
+const API_URL = process.env.REACT_APP_BACKEND_URL || "http://localhost:8001";
 
 const downloadFile = async (url, path, filename) => {
   const resp = await authService.authAxios.post(`${API_URL}/api/download`, {

--- a/frontend/src/services/imageService.js
+++ b/frontend/src/services/imageService.js
@@ -1,7 +1,7 @@
 import axios from 'axios';
 import authService from './authService';
 
-const API_URL = process.env.REACT_APP_BACKEND_URL || "";
+const API_URL = process.env.REACT_APP_BACKEND_URL || "http://localhost:8001";
 
 // Upload an image file
 const uploadImage = async (file) => {

--- a/frontend/src/services/loggingService.js
+++ b/frontend/src/services/loggingService.js
@@ -1,6 +1,6 @@
 import axios from 'axios';
 
-const API_URL = process.env.REACT_APP_BACKEND_URL || "";
+const API_URL = process.env.REACT_APP_BACKEND_URL || "http://localhost:8001";
 
 const logFrontend = async (payload) => {
   try {

--- a/frontend/src/services/modelService.js
+++ b/frontend/src/services/modelService.js
@@ -1,6 +1,6 @@
 import authService from './authService';
 
-const API_URL = process.env.REACT_APP_BACKEND_URL || "";
+const API_URL = process.env.REACT_APP_BACKEND_URL || "http://localhost:8001";
 
 const getModels = async () => {
   try {

--- a/frontend/src/services/parameterService.js
+++ b/frontend/src/services/parameterService.js
@@ -1,6 +1,6 @@
 import authService from './authService';
 
-const API_URL = process.env.REACT_APP_BACKEND_URL || "";
+const API_URL = process.env.REACT_APP_BACKEND_URL || "http://localhost:8001";
 
 // Get all parameter mappings
 const getParameterMappings = async () => {

--- a/frontend/src/services/progressService.js
+++ b/frontend/src/services/progressService.js
@@ -1,6 +1,6 @@
 import authService from './authService';
 
-const API_URL = process.env.REACT_APP_BACKEND_URL || "";
+const API_URL = process.env.REACT_APP_BACKEND_URL || "http://localhost:8001";
 
 // Subscribe to progress updates for a job using Server-Sent Events
 const subscribe = (jobId, onUpdate, onError) => {

--- a/frontend/src/services/workflowService.js
+++ b/frontend/src/services/workflowService.js
@@ -1,7 +1,7 @@
 import axios from 'axios';
 import authService from './authService';
 
-const API_URL = process.env.REACT_APP_BACKEND_URL || "";
+const API_URL = process.env.REACT_APP_BACKEND_URL || "http://localhost:8001";
 
 // Get all workflows from ComfyUI
 const getComfyUIWorkflows = async () => {


### PR DESCRIPTION
## Summary
- default to localhost backend for all services
- update example environment variables

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_683f45099e748329bc250774c992943e