### PR TITLE
Fix explore page and dropdown filters

### DIFF
--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -584,6 +584,66 @@ button:disabled {
   background: var(--accent-color);
 }
 
+.menu-buttons {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  position: relative;
+}
+
+.menu-button {
+  background: var(--bg-input);
+  border: 1px solid var(--border-color);
+  color: var(--text-primary);
+  padding: 6px 12px;
+  border-radius: 4px;
+  cursor: pointer;
+}
+
+.menu-button:hover {
+  background: var(--bg-hover);
+}
+
+.dropdown-menu {
+  position: absolute;
+  top: 110%;
+  right: 0;
+  background: var(--bg-card);
+  border: 1px solid var(--border-color);
+  border-radius: 6px;
+  padding: 10px;
+  z-index: 10;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.dropdown-menu .filter-group {
+  display: flex;
+  flex-direction: column;
+  margin-bottom: 8px;
+}
+
+.dropdown-menu .filter-group span {
+  font-size: 13px;
+  color: var(--text-secondary);
+  margin-bottom: 4px;
+}
+
+.dropdown-menu button {
+  background: none;
+  border: none;
+  color: var(--text-primary);
+  text-align: left;
+  padding: 4px 6px;
+  cursor: pointer;
+}
+
+.dropdown-menu button.active {
+  color: var(--accent-color);
+  font-weight: 500;
+}
+
 .search-container {
   position: relative;
 }

--- a/frontend/src/services/civitaiService.js
+++ b/frontend/src/services/civitaiService.js
@@ -1,7 +1,8 @@
 // Service for interacting with the Civitai API
 // Requests are proxied through the backend which handles authentication and
 // caching.  The base URL therefore points to our own API.
-const CIVITAI_API_URL = '/api/civitai';
+const API_URL = process.env.REACT_APP_BACKEND_URL || 'http://localhost:8001';
+const CIVITAI_API_URL = `${API_URL}/api/civitai`;
 
 // API key is stored securely on the backend. These helpers
 // allow the frontend to set the key without persisting it locally.
@@ -24,7 +25,7 @@ export const setApiKey = async (apiKey) => {
 
 // Helper for making API requests
 const makeRequest = async (endpoint, params = {}) => {
-  const url = new URL(`${CIVITAI_API_URL}${endpoint}`, window.location.origin);
+  const url = new URL(`${CIVITAI_API_URL}${endpoint}`);
   
   // Add params to URL
   Object.keys(params).forEach(key => {


### PR DESCRIPTION
## Summary
- use explicit backend URL for civitai service
- add dropdown Sort and Filter menus in the explore page
- toggle model and base model filters
- style new dropdown menus

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_683f496087f88329bb882f61de9edfce