### PR TITLE
Enable file picker on empty editor screen

### DIFF
--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -1319,6 +1319,11 @@ button:disabled {
   border-radius: 8px;
 }
 
+.editor-page .empty-state {
+  height: auto;
+  cursor: pointer;
+}
+
 .empty-state h2 {
   font-size: 1.5rem;
   margin-bottom: 10px;

--- a/frontend/src/components/ImageDropZone.js
+++ b/frontend/src/components/ImageDropZone.js
@@ -38,12 +38,15 @@ const ImageDropZone = ({ onImageDrop, onUploadClick }) => {
   };
   
   return (
-    <div 
+    <div
       className={`image-dropzone ${isDragging ? 'dragging' : ''}`}
       onDragOver={handleDragOver}
       onDragLeave={handleDragLeave}
       onDrop={handleDrop}
-      onClick={onUploadClick}
+      onClick={(e) => {
+        e.stopPropagation();
+        onUploadClick();
+      }}
     >
       <div className="dropzone-content">
         <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" strokeWidth={1.5} stroke="currentColor" width="40" height="40">

--- a/frontend/src/pages/EditorPage.js
+++ b/frontend/src/pages/EditorPage.js
@@ -285,15 +285,25 @@ const EditorPage = () => {
         onDragOver={handlePageDragOver}
         onDrop={handlePageDrop}
       >
-        <div className="empty-state">
+        <div className="empty-state" onClick={handleUploadClick}>
           <h2>No Image Selected</h2>
           <p>Upload or drop an image to start editing.</p>
           <div className="dropzone-container">
             <ImageDropZone
               onImageDrop={handleImageDrop}
-              onUploadClick={handleUploadClick}
+              onUploadClick={(e) => {
+                e.stopPropagation();
+                handleUploadClick();
+              }}
             />
           </div>
+          <input
+            type="file"
+            ref={fileInputRef}
+            style={{ display: 'none' }}
+            accept="image/*"
+            onChange={handleFileUpload}
+          />
         </div>
       </div>
     );


### PR DESCRIPTION
## Summary
- make the editor empty state clickable to open the image file picker
- add click stop propagation for the drop zone
- override empty state height in Editor page so it doesn't take full screen height

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_683f4af2a10c8329a52e2bdac2454ce4