### PR TITLE
Move job search box next to generate button

### DIFF
--- a/frontend/src/pages/CreatePage.js
+++ b/frontend/src/pages/CreatePage.js
@@ -367,29 +367,30 @@ const CreatePage = () => {
                 'Generate'
               )}
             </button>
+
+            <div className="search-container">
+              <input
+                type="text"
+                className="search-input"
+                placeholder="Search jobs..."
+                value={searchQuery}
+                onChange={handleSearch}
+              />
+              <svg
+                xmlns="http://www.w3.org/2000/svg"
+                fill="none"
+                viewBox="0 0 24 24"
+                strokeWidth={1.5}
+                stroke="currentColor"
+                className="search-icon"
+                width="20"
+                height="20"
+              >
+                <path strokeLinecap="round" strokeLinejoin="round" d="M21 21l-5.197-5.197m0 0A7.5 7.5 0 105.196 5.196a7.5 7.5 0 0010.607 10.607z" />
+              </svg>
+            </div>
           </div>
         </div>
-      </div>
-      <div className="search-container" style={{ marginTop: '10px' }}>
-        <input
-          type="text"
-          className="search-input"
-          placeholder="Search jobs..."
-          value={searchQuery}
-          onChange={handleSearch}
-        />
-        <svg
-          xmlns="http://www.w3.org/2000/svg"
-          fill="none"
-          viewBox="0 0 24 24"
-          strokeWidth={1.5}
-          stroke="currentColor"
-          className="search-icon"
-          width="20"
-          height="20"
-        >
-          <path strokeLinecap="round" strokeLinejoin="round" d="M21 21l-5.197-5.197m0 0A7.5 7.5 0 105.196 5.196a7.5 7.5 0 0010.607 10.607z" />
-        </svg>
       </div>
 
       <h2 className="yesterday-header">Yesterday</h2>


### PR DESCRIPTION
## Summary
- reposition search bar next to Generate button on create page

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_683f4f78915083298168102f5a2eef52