### PR TITLE
Improve settings page layout

### DIFF
--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -1439,3 +1439,56 @@ button:disabled {
 .status-indicator.online {
   background: var(--success-color);
 }
+
+/* Settings Page Styles */
+.settings-page {
+  max-width: 800px;
+  margin: 0 auto;
+}
+
+.settings-tabs {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  margin-bottom: 20px;
+}
+
+.settings-tab {
+  background: var(--bg-input);
+  color: var(--text-primary);
+  border: none;
+  padding: 6px 12px;
+  border-radius: 4px;
+  cursor: pointer;
+  transition: background 0.2s ease;
+}
+
+.settings-tab.active {
+  background: var(--accent-color);
+  color: #fff;
+}
+
+.settings-section {
+  background: var(--bg-card);
+  padding: 20px;
+  border-radius: 8px;
+  margin-bottom: 20px;
+}
+
+.settings-form .form-group input,
+.settings-form .form-group select {
+  max-width: 400px;
+}
+
+.settings-form button {
+  width: auto;
+  align-self: flex-start;
+}
+
+.backup-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 10px;
+  align-items: center;
+}
+


### PR DESCRIPTION
## Summary
- style the settings page to limit width and tidy layout

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_683f4f8c13948329865134ee8214ce6d