### PR TITLE
Add voice input and Whisper endpoints

### DIFF
--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -28,4 +28,5 @@ aiofiles>=0.8.0
 Pillow>=10.0.0
 bcrypt>=4.1.0
 sqlalchemy>=2.0.36
+openai-whisper>=20230314
 psycopg2-binary>=2.9.10

--- a/frontend/src/components/AdvancedEditor.js
+++ b/frontend/src/components/AdvancedEditor.js
@@ -2,6 +2,7 @@ import React, { useState, useRef, useEffect } from 'react';
 import { Stage, Layer, Image, Line, Rect, Transformer } from 'react-konva';
 import useImage from 'use-image';
 import Konva from 'konva';
+import VoiceInput from './VoiceInput';
 
 const AdvancedEditor = ({
   image,
@@ -293,12 +294,21 @@ const clearMask = () => {
   }; 
    
   // Handle saving 
-  const handleSave = () => { 
+  const handleSave = () => {
     if (onSave) { 
       const stage = stageRef.current; 
       const dataUrl = stage.toDataURL(); 
       onSave(dataUrl); 
     } 
+  };
+
+  const handleVoiceResult = (text) => {
+    const prefs = JSON.parse(localStorage.getItem('comfyui_preferences') || '{}');
+    if (prefs.voicePlacement === 'prepend') {
+      onGenerateInpaint(`${text} ${prompt}`, null);
+    } else {
+      onGenerateInpaint(`${prompt} ${text}`, null);
+    }
   };
 
   // Toggle crop mode
@@ -730,6 +740,7 @@ const clearMask = () => {
           value={prompt}
           onChange={(e) => onGenerateInpaint(e.target.value, null)}
         />
+        <VoiceInput onResult={handleVoiceResult} />
       </div>
     </div>
   );

--- a/frontend/src/components/VoiceInput.js
+++ b/frontend/src/components/VoiceInput.js
@@ -1,0 +1,53 @@
+import React, { useState, useRef } from 'react';
+import voiceService from '../services/voiceService';
+
+const VoiceInput = ({ onResult }) => {
+  const [open, setOpen] = useState(false);
+  const [recording, setRecording] = useState(false);
+  const mediaRef = useRef(null);
+  const chunksRef = useRef([]);
+
+  const startRecording = async () => {
+    try {
+      const prefs = JSON.parse(localStorage.getItem('comfyui_preferences') || '{}');
+      const stream = await navigator.mediaDevices.getUserMedia({ audio: { deviceId: prefs.audioInputId || undefined } });
+      const rec = new MediaRecorder(stream);
+      mediaRef.current = rec;
+      chunksRef.current = [];
+      rec.ondataavailable = e => {
+        if (e.data && e.data.size > 0) chunksRef.current.push(e.data);
+      };
+      rec.onstop = async () => {
+        const blob = new Blob(chunksRef.current, { type: 'audio/webm' });
+        const text = await voiceService.transcribe(blob);
+        if (text && onResult) onResult(text);
+      };
+      rec.start();
+      setRecording(true);
+    } catch (err) {
+      console.error('Failed to start recording', err);
+    }
+  };
+
+  const stopRecording = () => {
+    mediaRef.current && mediaRef.current.stop();
+    setRecording(false);
+  };
+
+  return (
+    <div className="voice-input">
+      <button className="mic-button" onClick={() => setOpen(o => !o)}>
+        <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="18" height="18">
+          <path fill="none" stroke="currentColor" strokeWidth="1.5" d="M12 1.5a3 3 0 00-3 3v6a3 3 0 006 0v-6a3 3 0 00-3-3zM5.25 10.5v1.5a6.75 6.75 0 0013.5 0v-1.5M12 19.5v3m-3 0h6"/>
+        </svg>
+      </button>
+      {open && (
+        <button className="record-button" onClick={recording ? stopRecording : startRecording}>
+          {recording ? 'Done' : 'Start'}
+        </button>
+      )}
+    </div>
+  );
+};
+
+export default VoiceInput;

--- a/frontend/src/pages/EditorPage.js
+++ b/frontend/src/pages/EditorPage.js
@@ -2,6 +2,7 @@ import React, { useState, useEffect, useRef } from 'react';
 import { useLocation } from 'react-router-dom';
 import Toast from '../components/Toast';
 import ImageDropZone from '../components/ImageDropZone';
+import VoiceInput from '../components/VoiceInput';
 
 const EditorPage = () => {
   const [image, setImage] = useState(null);
@@ -270,6 +271,15 @@ const EditorPage = () => {
     showToast('Inpainting request sent!', 'success');
   };
 
+  const handleVoiceResult = (text) => {
+    const prefs = JSON.parse(localStorage.getItem('comfyui_preferences') || '{}');
+    if (prefs.voicePlacement === 'prepend') {
+      setPrompt(prev => `${text} ${prev}`.trim());
+    } else {
+      setPrompt(prev => `${prev} ${text}`.trim());
+    }
+  };
+
   const showToast = (message, type = 'info') => {
     setToast({ message, type });
   };
@@ -464,6 +474,7 @@ const EditorPage = () => {
             value={prompt}
             onChange={(e) => setPrompt(e.target.value)}
           />
+          <VoiceInput onResult={handleVoiceResult} />
           
           <div className="control-buttons">
             <button 

--- a/frontend/src/pages/HomePage.js
+++ b/frontend/src/pages/HomePage.js
@@ -1,4 +1,5 @@
 import React, { useState, useEffect, useRef } from 'react';
+import VoiceInput from '../components/VoiceInput';
 import { useLocation } from 'react-router-dom';
 import ImageDropZone from '../components/ImageDropZone';
 import ImageCard from '../components/ImageCard';
@@ -338,6 +339,15 @@ const HomePage = () => {
     }
   };
 
+  const handleVoiceResult = (text) => {
+    const prefs = JSON.parse(localStorage.getItem('comfyui_preferences') || '{}');
+    if (prefs.voicePlacement === 'prepend') {
+      setPrompt((prev) => `${text} ${prev}`.trim());
+    } else {
+      setPrompt((prev) => `${prev} ${text}`.trim());
+    }
+  };
+
   return (
     <div className="home-page">
       {toast && (
@@ -366,7 +376,8 @@ const HomePage = () => {
             />
             
             <div className="prompt-options">
-              <select 
+              <VoiceInput onResult={handleVoiceResult} />
+              <select
                 value={selectedModel}
                 onChange={(e) => setSelectedModel(e.target.value)}
                 disabled={generating}

--- a/frontend/src/services/voiceService.js
+++ b/frontend/src/services/voiceService.js
@@ -1,0 +1,27 @@
+import authService from './authService';
+
+const API_URL = process.env.REACT_APP_BACKEND_URL || "http://localhost:8001";
+
+const transcribe = async (blob) => {
+  const form = new FormData();
+  form.append('file', blob, 'audio.webm');
+  try {
+    const resp = await authService.authAxios.post(`${API_URL}/api/transcribe`, form, {
+      headers: { 'Content-Type': 'multipart/form-data' }
+    });
+    return resp.data?.payload?.text || '';
+  } catch (err) {
+    console.error('Transcription failed', err);
+    return '';
+  }
+};
+
+const downloadModel = async (model) => {
+  try {
+    await authService.authAxios.post(`${API_URL}/api/whisper/download?model=${model}`);
+  } catch (err) {
+    console.error('Model download failed', err);
+  }
+};
+
+export default { transcribe, downloadModel };

--- a/tests/test_transcribe.py
+++ b/tests/test_transcribe.py
@@ -1,0 +1,33 @@
+import os
+import sys
+import types
+from fastapi.testclient import TestClient
+
+os.environ["DATABASE_URL"] = "sqlite:///./test.db"
+os.environ["DISABLE_CSRF"] = "true"
+
+# stub whisper before importing app
+whisper_mod = types.ModuleType("whisper")
+class DummyModel:
+    def transcribe(self, path):
+        return {"text": "hello world"}
+
+def load_model(name):
+    return DummyModel()
+
+whisper_mod.load_model = load_model
+whisper_mod._download = lambda model, download_root=None: None
+sys.modules["whisper"] = whisper_mod
+import fastapi.dependencies.utils as dep_utils
+dep_utils.ensure_multipart_is_installed = lambda: None
+
+from backend.models import init_db
+from backend.server import app
+
+init_db()
+client = TestClient(app)
+
+def test_transcribe_endpoint():
+    resp = client.post("/api/transcribe", files={"file": ("a.webm", b"0")})
+    assert resp.status_code == 200
+    assert resp.json()["payload"]["text"] == "hello world"


### PR DESCRIPTION
## Summary
- implement backend `/transcribe` and `/whisper/download` routes
- add voice recorder component and service
- integrate voice to text on prompt inputs
- add notification sound and audio device settings
- expose whisper model settings under Paths
- add tests for new transcribe endpoint

## Testing
- `pytest tests/test_transcribe.py::test_transcribe_endpoint -q`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_683f57d8c45c8329aa4f12901814214b