### PR TITLE
Add tags and detail endpoints for Civitai API

### DIFF
--- a/backend/server.py
+++ b/backend/server.py
@@ -827,6 +827,24 @@ async def civitai_models(request: Request, limit: int = 20, page: int = 1):
     return api_response(data)
 
 
+@api_router.get("/civitai/models/{model_id}")
+async def civitai_model_detail(model_id: str, request: Request):
+    """Proxy to fetch a specific model by ID from Civitai."""
+    api_key = await get_civitai_key()
+    params = dict(request.query_params)
+    data = await civitai_fetch(f"/models/{model_id}", params=params, api_key=api_key)
+    return api_response(data)
+
+
+@api_router.get("/civitai/tags")
+async def civitai_tags(request: Request):
+    """Proxy to Civitai tags endpoint forwarding all query parameters."""
+    api_key = await get_civitai_key()
+    params = dict(request.query_params)
+    data = await civitai_fetch("/tags", params=params, api_key=api_key)
+    return api_response(data)
+
+
 # ---------------------------------------------------------------------------
 # Maintenance endpoint
 # ---------------------------------------------------------------------------

--- a/tests/test_civitai_endpoints.py
+++ b/tests/test_civitai_endpoints.py
@@ -104,3 +104,56 @@ def test_videos_forwarded(monkeypatch):
     assert captured["params"]["page"] == "1"
     assert captured["params"]["sort"] == "Newest"
     assert captured["params"]["period"] == "Month"
+
+
+def test_models_forwarded(monkeypatch):
+    captured = {}
+
+    async def dummy_fetch(endpoint, params=None, api_key=None):
+        captured["endpoint"] = endpoint
+        captured["params"] = params
+        return {}
+
+    monkeypatch.setattr(server, "civitai_fetch", dummy_fetch)
+
+    resp = client.get(
+        "/api/civitai/models",
+        params={"limit": 10, "page": 3, "sort": "Highest Rated"},
+    )
+    assert resp.status_code == 200
+    assert captured["endpoint"] == "/models"
+    assert captured["params"]["limit"] == "10"
+    assert captured["params"]["page"] == "3"
+    assert captured["params"]["sort"] == "Highest Rated"
+
+
+def test_model_detail_forwarded(monkeypatch):
+    captured = {}
+
+    async def dummy_fetch(endpoint, params=None, api_key=None):
+        captured["endpoint"] = endpoint
+        captured["params"] = params
+        return {}
+
+    monkeypatch.setattr(server, "civitai_fetch", dummy_fetch)
+
+    resp = client.get("/api/civitai/models/123", params={"versionId": "456"})
+    assert resp.status_code == 200
+    assert captured["endpoint"] == "/models/123"
+    assert captured["params"]["versionId"] == "456"
+
+
+def test_tags_forwarded(monkeypatch):
+    captured = {}
+
+    async def dummy_fetch(endpoint, params=None, api_key=None):
+        captured["endpoint"] = endpoint
+        captured["params"] = params
+        return {}
+
+    monkeypatch.setattr(server, "civitai_fetch", dummy_fetch)
+
+    resp = client.get("/api/civitai/tags", params={"query": "foo"})
+    assert resp.status_code == 200
+    assert captured["endpoint"] == "/tags"
+    assert captured["params"]["query"] == "foo"


### PR DESCRIPTION
## Summary
- support `/api/civitai/models/{id}` endpoint
- support `/api/civitai/tags` endpoint
- extend tests to cover new endpoints

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_683f705d734883298d935d696934e71e