### PR TITLE
Implement disk cache for Civitai client

### DIFF
--- a/requests.py
+++ b/requests.py
@@ -83,6 +83,10 @@ class Response:
     def json(self):
         return self._json
 
+    def raise_for_status(self):
+        if not (200 <= self.status_code < 300):
+            raise Exception(f"HTTP {self.status_code}")
+
 
 def _strip_base(url: str) -> str:
     if '/api' in url:

--- a/tests/test_civitai_cache.py
+++ b/tests/test_civitai_cache.py
@@ -1,0 +1,41 @@
+import os
+import types
+import asyncio
+import hashlib
+
+from backend.external_integrations import civitai
+
+class DummyResponse:
+    def __init__(self, data):
+        self._data = data
+    def raise_for_status(self):
+        pass
+    def json(self):
+        return self._data
+
+class DummyClient:
+    def __init__(self):
+        self.calls = 0
+    async def get(self, *args, **kwargs):
+        self.calls += 1
+        return DummyResponse({"call": self.calls})
+
+async def run(tmpdir, client):
+    civitai._CACHE.clear()
+    civitai._last_request_time = 0.0
+    civitai.CACHE_DIR = tmpdir
+    os.makedirs(tmpdir, exist_ok=True)
+    civitai._HTTP_CLIENT = client
+    data1 = await civitai.fetch_json("/foo")
+    data2 = await civitai.fetch_json("/foo")
+    assert data1 == data2
+    assert client.calls == 1
+    key = civitai._cache_key("/foo", None, None)
+    cached_path = os.path.join(tmpdir, hashlib.sha256(key.encode()).hexdigest()+".json")
+    assert os.path.exists(cached_path)
+
+
+def test_disk_cache(tmp_path, monkeypatch):
+    client = DummyClient()
+    monkeypatch.setattr(civitai, "httpx", types.SimpleNamespace(AsyncClient=lambda *a, **k: client))
+    asyncio.run(run(str(tmp_path), client))


### PR DESCRIPTION
## Summary
- extend `requests.Response` stub with `raise_for_status`
- add optional disk caching to Civitai API helper
- new unit test covering disk caching logic

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_683fb36d954083299a34492fc808cbe1