### PR TITLE
Add explore item cycling with modal viewer

### DIFF
--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -1492,3 +1492,70 @@ button:disabled {
   align-items: center;
 }
 
+/* Explore page extras */
+.card-controls {
+  display: none;
+  justify-content: center;
+  gap: 8px;
+  margin-top: 6px;
+}
+
+.image-card:hover .card-controls,
+.model-card:hover .card-controls {
+  display: flex;
+}
+
+.card-controls button {
+  background: var(--bg-input);
+  border: 1px solid var(--border-color);
+  color: var(--text-primary);
+  padding: 2px 6px;
+  border-radius: 4px;
+  cursor: pointer;
+}
+
+.modal-overlay {
+  position: fixed;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.8);
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  z-index: 1000;
+}
+
+.modal-content {
+  background: var(--bg-card);
+  padding: 20px;
+  border-radius: 8px;
+  max-width: 90%;
+  max-height: 90%;
+  overflow: auto;
+  display: flex;
+  gap: 20px;
+}
+
+.modal-media {
+  max-width: 60vw;
+  max-height: 80vh;
+}
+
+.modal-info {
+  display: flex;
+  flex-direction: column;
+  justify-content: space-between;
+}
+
+.version-controls {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  margin-bottom: 8px;
+}
+
+.modal-actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: 8px;
+}
+

--- a/tests/test_civitai_live.py
+++ b/tests/test_civitai_live.py
@@ -1,0 +1,20 @@
+import os
+import asyncio
+import pytest
+from backend.external_integrations.civitai import fetch_json
+
+API_KEY = os.environ.get('CIVITAI_TEST_API_KEY')
+
+@pytest.mark.skipif(not API_KEY, reason='CIVITAI_TEST_API_KEY not set')
+def test_fetch_images_live():
+    async def run():
+        data = await fetch_json('/images', params={'limit':1}, api_key=API_KEY)
+        assert data
+    asyncio.run(run())
+
+@pytest.mark.skipif(not API_KEY, reason='CIVITAI_TEST_API_KEY not set')
+def test_fetch_model_live():
+    async def run():
+        data = await fetch_json('/models', params={'limit':1}, api_key=API_KEY)
+        assert data
+    asyncio.run(run())


### PR DESCRIPTION
## Summary
- add image/video/model/workflow cycling buttons
- show media modal with prompt/details and model version controls
- style card controls and modal
- add live Civitai API integration tests

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_683fbbd5373c83299870ca9533bdcaf6