### PR TITLE
Fix invalid Civitai query params

### DIFF
--- a/frontend/src/services/civitaiService.js
+++ b/frontend/src/services/civitaiService.js
@@ -27,10 +27,11 @@ export const setApiKey = async (apiKey) => {
 const makeRequest = async (endpoint, params = {}) => {
   const url = new URL(`${CIVITAI_API_URL}${endpoint}`);
   
-  // Add params to URL
+  // Add params to URL, skipping empty strings to avoid invalid requests
   Object.keys(params).forEach(key => {
-    if (params[key] !== undefined && params[key] !== null) {
-      url.searchParams.append(key, params[key]);
+    const value = params[key];
+    if (value !== undefined && value !== null && value !== '') {
+      url.searchParams.append(key, value);
     }
   });
   


### PR DESCRIPTION
## Summary
- skip empty strings when building Civitai API requests in the frontend

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_b_683fbe8067e4832980aaa0638df47405