### PR TITLE
Fix Civitai API params

### DIFF
--- a/frontend/src/pages/ExplorePage.js
+++ b/frontend/src/pages/ExplorePage.js
@@ -26,15 +26,15 @@ const SORT_OPTIONS = [
 
 const MODEL_TYPES = [
   'Checkpoint',
-  'Embedding',
+  'TextualInversion',
   'Hypernetwork',
-  'Aesthetic Gradient',
-  'LoRA',
-  'LyCORIS',
+  'AestheticGradient',
+  'LORA',
+  'LoCon',
   'DoRA',
   'Controlnet',
   'Upscaler',
-  'Motion',
+  'MotionModule',
   'VAE',
   'Poses',
   'Wildcards',
@@ -155,7 +155,7 @@ const ExplorePage = () => {
         const imgRes = await civitaiService.getImages({ limit: 20, page, nsfw: showNsfw, sort, period, baseModel });
         const vidRes = await civitaiService.getVideos({ limit: 20, page, nsfw: showNsfw, sort, period, baseModel });
         const modRes = await civitaiService.getModels({ limit: 20, page, sort, period, types: modelType, baseModel });
-        const wfRes = await civitaiService.getModels({ limit: 20, page, types: 'Workflow', sort, period, baseModel });
+        const wfRes = await civitaiService.getModels({ limit: 20, page, types: 'Workflows', sort, period, baseModel });
 
         const newImages = imgRes.items || imgRes.data || imgRes;
         const newVideos = vidRes.items || vidRes.data || vidRes;

--- a/frontend/src/services/civitaiService.js
+++ b/frontend/src/services/civitaiService.js
@@ -30,7 +30,12 @@ const makeRequest = async (endpoint, params = {}) => {
   // Add params to URL, skipping empty strings to avoid invalid requests
   Object.keys(params).forEach(key => {
     const value = params[key];
-    if (value !== undefined && value !== null && value !== '') {
+    if (value === undefined || value === null || value === '') {
+      return;
+    }
+    if (Array.isArray(value)) {
+      value.forEach(v => url.searchParams.append(`${key}[]`, v));
+    } else {
       url.searchParams.append(key, value);
     }
   });


### PR DESCRIPTION
## Summary
- update model type names to match Civitai enums
- fix workflow query parameter
- support array query params in Civitai service

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_683fce50fe2c8329ae2ae3585beeb61f