### PR TITLE
Use /api/v1 for Civitai routes

### DIFF
--- a/backend/server.py
+++ b/backend/server.py
@@ -799,19 +799,19 @@ async def comfyui_restart(request: Request):
 # ---------------------------------------------------------------------------
 
 
-@api_router.post("/civitai/key")
+@api_router.post("/v1/key")
 async def set_civitai_key(key: CivitaiKey):
     await store_civitai_key(key.api_key)
     return api_response({"message": "API key saved"})
 
 
-@api_router.get("/civitai/key")
+@api_router.get("/v1/key")
 async def has_civitai_key():
     key = await get_civitai_key()
     return api_response({"key_set": bool(key)})
 
 
-@api_router.get("/civitai/images")
+@api_router.get("/v1/images")
 async def civitai_images(request: Request, limit: int = 20, page: int = 1):
     """Proxy to Civitai image search forwarding all query parameters."""
     api_key = await get_civitai_key()
@@ -822,7 +822,7 @@ async def civitai_images(request: Request, limit: int = 20, page: int = 1):
     return api_response(data)
 
 
-@api_router.get("/civitai/videos")
+@api_router.get("/v1/videos")
 async def civitai_videos(request: Request, limit: int = 20, page: int = 1):
     """Proxy to Civitai video search forwarding all query parameters."""
     api_key = await get_civitai_key()
@@ -840,7 +840,7 @@ async def civitai_videos(request: Request, limit: int = 20, page: int = 1):
     return api_response(data)
 
 
-@api_router.get("/civitai/models")
+@api_router.get("/v1/models")
 async def civitai_models(request: Request, limit: int = 20, page: int = 1):
     """Proxy to Civitai model search forwarding all query parameters."""
     api_key = await get_civitai_key()
@@ -851,7 +851,7 @@ async def civitai_models(request: Request, limit: int = 20, page: int = 1):
     return api_response(data)
 
 
-@api_router.get("/civitai/models/{model_id}")
+@api_router.get("/v1/models/{model_id}")
 async def civitai_model_detail(model_id: str, request: Request):
     """Proxy to fetch a specific model by ID from Civitai."""
     api_key = await get_civitai_key()
@@ -860,7 +860,7 @@ async def civitai_model_detail(model_id: str, request: Request):
     return api_response(data)
 
 
-@api_router.get("/civitai/tags")
+@api_router.get("/v1/tags")
 async def civitai_tags(request: Request):
     """Proxy to Civitai tags endpoint forwarding all query parameters."""
     api_key = await get_civitai_key()

--- a/frontend/src/services/civitaiService.js
+++ b/frontend/src/services/civitaiService.js
@@ -2,7 +2,7 @@
 // Requests are proxied through the backend which handles authentication and
 // caching.  The base URL therefore points to our own API.
 const API_URL = process.env.REACT_APP_BACKEND_URL || 'http://localhost:8001';
-const CIVITAI_API_URL = `${API_URL}/api/civitai`;
+const CIVITAI_API_URL = `${API_URL}/api/v1`;
 
 // API key is stored securely on the backend. These helpers
 // allow the frontend to set the key without persisting it locally.
@@ -11,7 +11,7 @@ let CIVITAI_API_KEY = '';
 export const setApiKey = async (apiKey) => {
   CIVITAI_API_KEY = apiKey;
   try {
-    await fetch('/api/civitai/key', {
+    await fetch('/api/v1/key', {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({ api_key: apiKey })
@@ -188,7 +188,7 @@ export const uploadImage = async (imageUrl, promptText, workflowId) => {
 // Check if API key is valid
 export const checkApiKey = async () => {
   try {
-    const res = await fetch('/api/civitai/key');
+    const res = await fetch('/api/v1/key');
     if (!res.ok) return false;
     const data = await res.json();
     return data.payload && data.payload.key_set;

--- a/tests/test_civitai_endpoints.py
+++ b/tests/test_civitai_endpoints.py
@@ -66,7 +66,7 @@ def test_query_parameters_forwarded(monkeypatch):
     monkeypatch.setattr(server, "civitai_fetch", dummy_fetch)
 
     resp = client.get(
-        "/api/civitai/images",
+        "/api/v1/images",
         params={
             "limit": 5,
             "page": 2,
@@ -95,7 +95,7 @@ def test_videos_forwarded(monkeypatch):
     monkeypatch.setattr(server, "civitai_fetch", dummy_fetch)
 
     resp = client.get(
-        "/api/civitai/videos",
+        "/api/v1/videos",
         params={"limit": 3, "page": 1, "sort": "Newest", "period": "Month"},
     )
     assert resp.status_code == 200
@@ -117,7 +117,7 @@ def test_models_forwarded(monkeypatch):
     monkeypatch.setattr(server, "civitai_fetch", dummy_fetch)
 
     resp = client.get(
-        "/api/civitai/models",
+        "/api/v1/models",
         params={"limit": 10, "page": 3, "sort": "Highest Rated"},
     )
     assert resp.status_code == 200
@@ -137,7 +137,7 @@ def test_model_detail_forwarded(monkeypatch):
 
     monkeypatch.setattr(server, "civitai_fetch", dummy_fetch)
 
-    resp = client.get("/api/civitai/models/123", params={"versionId": "456"})
+    resp = client.get("/api/v1/models/123", params={"versionId": "456"})
     assert resp.status_code == 200
     assert captured["endpoint"] == "/models/123"
     assert captured["params"]["versionId"] == "456"
@@ -153,7 +153,7 @@ def test_tags_forwarded(monkeypatch):
 
     monkeypatch.setattr(server, "civitai_fetch", dummy_fetch)
 
-    resp = client.get("/api/civitai/tags", params={"query": "foo"})
+    resp = client.get("/api/v1/tags", params={"query": "foo"})
     assert resp.status_code == 200
     assert captured["endpoint"] == "/tags"
     assert captured["params"]["query"] == "foo"


### PR DESCRIPTION
## Summary
- update frontend Civitai service to talk to `/api/v1`
- rename backend Civitai proxy routes to `/api/v1`
- adjust tests for new endpoints

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_68402b29bd688329a80623b189642b70