### PR TITLE
Fix encoding of sort params for Civitai API

### DIFF
--- a/backend/external_integrations/civitai.py
+++ b/backend/external_integrations/civitai.py
@@ -8,6 +8,7 @@ import os
 import time
 from typing import Any, Dict, Optional, Tuple
 import hashlib
+import urllib.parse
 
 import httpx
 
@@ -85,8 +86,11 @@ async def fetch_json(
         headers["Authorization"] = f"Bearer {api_key}"
 
     url = f"{BASE_URL}{path}"
+    if params:
+        query = urllib.parse.urlencode(params, doseq=True, quote_via=urllib.parse.quote)
+        url = f"{url}?{query}"
     client = await _get_client()
-    resp = await client.get(url, params=params, headers=headers, timeout=10)
+    resp = await client.get(url, headers=headers, timeout=10)
     resp.raise_for_status()
     data = resp.json()
 

--- a/frontend/src/services/civitaiService.js
+++ b/frontend/src/services/civitaiService.js
@@ -42,8 +42,10 @@ const makeRequest = async (endpoint, params = {}) => {
   
   const options = {};
   
+  const finalUrl = url.toString().replace(/\+/g, '%20');
+
   try {
-    const response = await fetch(url.toString(), options);
+    const response = await fetch(finalUrl, options);
 
     if (!response.ok) {
       throw new Error(`API error: ${response.status}`);


### PR DESCRIPTION
## Summary
- ensure frontend always encodes spaces in query params using `%20`
- ensure backend uses `urllib.parse.urlencode` with `quote` to avoid `+` encoding

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_6840d048aa488329aed7dcbc839b19c8