### PR TITLE
Fix Explore models tab rendering

### DIFF
--- a/frontend/src/pages/ExplorePage.js
+++ b/frontend/src/pages/ExplorePage.js
@@ -365,9 +365,22 @@ const ExplorePage = () => {
     setModelDetail(null);
   };
 
-  const filtered = (arr, fields) => arr.filter(item =>
-    fields.some(f => (item[f] || '').toLowerCase().includes(searchQuery.toLowerCase()))
-  );
+  const getFieldString = (obj, field) => {
+    const val = obj[field];
+    if (!val) return '';
+    if (typeof val === 'string') return val;
+    if (typeof val === 'object' && val.username) return val.username;
+    return String(val);
+  };
+
+  const filtered = (arr, fields) =>
+    arr.filter(item =>
+      fields.some(f =>
+        getFieldString(item, f)
+          .toLowerCase()
+          .includes(searchQuery.toLowerCase())
+      )
+    );
 
   const filteredImages = filtered(images, ['prompt', 'username']);
   const filteredVideos = filtered(videos, ['prompt', 'username']);
@@ -517,7 +530,7 @@ const ExplorePage = () => {
                     </div>
                     <p className="model-description">{displayModel.description}</p>
                     <div className="model-meta">
-                      <span className="model-creator">By @{displayModel.creator}</span>
+                      <span className="model-creator">By @{displayModel.creator?.username || displayModel.creator}</span>
                       <span className="model-downloads">{displayModel.downloads}</span>
                     </div>
                     <div className="card-controls">


### PR DESCRIPTION
## Summary
- fix model filtering logic in ExplorePage to handle `creator` objects
- show username in model card instead of `[object Object]`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_6840d492cb308329a63fc101cfc4f4b4